### PR TITLE
Add Monitor Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ hdmi_cec:
   # the address configured above) and broadcast messages. Enabling promiscuous mode will make the component
   # listen for all messages (both in logs and the on_message triggers)
   promiscuous_mode: false # Optional. Defaults to false
+  # By default, monitor mode is disabled, so the component can send messages and acknowledge incoming messages.
+  # Enabling monitor mode lets the component act as a passive listener, disabling active manipulation of the CEC bus.
+  monitor_mode: false # Optional. Defaults to false
   # List of triggers to handle specific commands. Each trigger has the following optional filter parameters:
   # - "source": match messages coming from the specified address
   # - "destination": match messages meant for the specified address

--- a/components/hdmi_cec/__init__.py
+++ b/components/hdmi_cec/__init__.py
@@ -12,6 +12,7 @@ CONF_PIN = "pin"
 CONF_ADDRESS = "address"
 CONF_PHYSICAL_ADDRESS = "physical_address"
 CONF_PROMISCUOUS_MODE = "promiscuous_mode"
+CONF_MONITOR_MODE = "monitor_mode"
 CONF_OSD_NAME = "osd_name"
 CONF_ON_MESSAGE = "on_message"
 
@@ -60,6 +61,7 @@ CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend(
         cv.Required(CONF_ADDRESS): cv.int_range(min=0, max=15),
         cv.Required(CONF_PHYSICAL_ADDRESS): cv.uint16_t,
         cv.Optional(CONF_PROMISCUOUS_MODE, False): cv.boolean,
+        cv.Optional(CONF_MONITOR_MODE, False): cv.boolean,
         cv.Optional(CONF_OSD_NAME, "esphome"): validate_osd_name,
         cv.Optional(CONF_ON_MESSAGE): automation.validate_automation(
             {
@@ -83,6 +85,7 @@ async def to_code(config):
     cg.add(var.set_address(config[CONF_ADDRESS]))
     cg.add(var.set_physical_address(config[CONF_PHYSICAL_ADDRESS]))
     cg.add(var.set_promiscuous_mode(config[CONF_PROMISCUOUS_MODE]))
+    cg.add(var.set_monitor_mode(config[CONF_MONITOR_MODE]))
 
     osd_name_bytes = bytes(config[CONF_OSD_NAME], 'ascii', 'ignore') # convert string to ascii bytes
     osd_name_bytes = [x for x in osd_name_bytes] # convert byte array to int array

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -27,6 +27,7 @@ public:
   uint8_t address() { return address_; }
   void set_physical_address(uint16_t physical_address) { physical_address_ = physical_address; }
   void set_promiscuous_mode(bool promiscuous_mode) { promiscuous_mode_ = promiscuous_mode; }
+  void set_monitor_mode(bool monitor_mode) { monitor_mode_ = monitor_mode; }
   void set_osd_name_bytes(const std::vector<uint8_t> &osd_name_bytes) { osd_name_bytes_ = osd_name_bytes; }
   void add_message_trigger(MessageTrigger *trigger) { message_triggers_.push_back(trigger); }
 
@@ -54,6 +55,7 @@ protected:
   uint8_t address_;
   uint16_t physical_address_;
   bool promiscuous_mode_;
+  bool monitor_mode_;
   std::vector<uint8_t> osd_name_bytes_;
   std::vector<MessageTrigger*> message_triggers_;
 


### PR DESCRIPTION
This PR adds a monitor mode to the repo. When monitor mode is enabled, no messages or acknowledgements are sent. The component truly acts as a passive listener.

In my case I had a TV and a sound system already connected over HDMI CEC. For some reason the volume control wasn't working so I added an ESP to the existing HDMI connection to listen for volume commands and transmit corresponding IR commands to the sound system. Since the sound system already responds to the CEC messages, I only want to listen for volume commands without replying to not confuse the other CEC participants.