### PR TITLE
Added pin setup to fix issues with ESP32-C3

### DIFF
--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -37,6 +37,7 @@ std::string bytes_to_string(std::vector<uint8_t> bytes) {
 }
 
 void HDMICEC::setup() {
+  this->pin_->setup();  
   isr_pin_ = pin_->to_isr();
   recv_frame_buffer_.reserve(16); // max 16 bytes per CEC frame
   pin_->attach_interrupt(HDMICEC::gpio_intr_, this, gpio::INTERRUPT_ANY_EDGE);


### PR DESCRIPTION
Fix for issue #7 

On ESP32-C3, `pin_->setup()` needs to be called, otherwise the pin does not respond to `digitalWrite`. At least on ESP32-S3, this was not needed, but it is needed on C3.