### PR TITLE
fix receiving of messages: removing allocation from isr

### DIFF
--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -359,7 +359,7 @@ void IRAM_ATTR HDMICEC::gpio_intr_(HDMICEC *self) {
   const uint32_t now = micros();
   const bool level = self->isr_pin_.digital_read();
 
-  if ((level && self->last_falling_edge_us_ == 0) || level == self->last_level_) {
+  if (level == self->last_level_) {
     // spurious interrupt, probably resulting from a pin mode change
     return;
   }
@@ -396,7 +396,7 @@ void IRAM_ATTR HDMICEC::gpio_intr_(HDMICEC *self) {
     // short glitch on the line: ignore
     return;
   }
-  
+
   bool value = (pulse_duration >= HIGH_BIT_MIN_US && pulse_duration <= HIGH_BIT_MAX_US);
   
   switch (self->receiver_state_) {

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -109,7 +109,6 @@ protected:
   void set_pin_input_high();
   void set_pin_output_low();
 
-  constexpr static int MAX_FRAME_LEN = 16;
   constexpr static int MAX_FRAMES_QUEUED = 4;
   InternalGPIOPin *pin_;
   ISRInternalGPIOPin isr_pin_;
@@ -127,7 +126,7 @@ protected:
   uint8_t recv_bit_counter_ = 0;
   uint8_t recv_byte_buffer_ = 0;
   Frame *frame_receive_ = nullptr;
-  FrameRingBuffer<4> frames_queue_;
+  FrameRingBuffer<MAX_FRAMES_QUEUED> frames_queue_;
   bool recv_ack_queued_ = false;
   Mutex send_mutex_;
 };


### PR DESCRIPTION
Fix https://github.com/Palakis/esphome-native-hdmi-cec/issues/10
The esp32c3 seems more critical for its resources. As mentioned in this issue, the receiving of messages didn't work.

There seemed to be two separate causes behind this issue, which are fixed with this update:

- The suppression of interrupts during locally sent messages did not work as expected. That is resolved by de-attaching and re-attaching the `gpio_intr_()` around sending. As positive side-effect of this change, it does not anymore block interrupts for long periods of time, which helps for system stability such as wifi. Furthermore, some spurious isr calls are now suppressed. 
- The use of the `std::queue` for transferring received messages from `gpio_intr_()` to `loop()` caused the kernel to crash. That queue is now replaced by a `std::vector` of (pointers to) frames, used with a fixed set of pre-allocated frane buffers: This avoids dynamic memory allocation in this isr. Unfortunately, this took quite some code lines to fix.

Although this is made to fix an issue which occurs on a the esp32c3 platform, I believe it is a genuine improvement also for the other platforms.