### PR TITLE
Updated README for clarity and beginner-friendliness + advanced configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ hdmi_cec:
   
   # Physical address of the device. In this case: 4.2.0.0 (The ESP32 is plugged into HDMI 2 on the receiver which is plugged into HDMI4 on the TV)
   # DDC support is not yet implemented, so you'll have to set this manually.
-  physical_address: 0x4000 # Required
+  physical_address: 0x4200 # Required
   
   # The name that will we displayed in the list of devices on your TV/receiver
   osd_name: "HDMI Bridge" # Optional. Defaults to "esphome"

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Make your ESPHome devices speak the (machine) language of your living room with 
 
 Connect the microcontroller to an HDMI connector (HDMI connectors and breakout boards can be found on Amazon and AliExpress)
 
-| [HDMI Pin](https://en.wikipedia.org/wiki/HDMI) | Description    | Connect to microcontroller pin                           |
-| -------- | -------------- | ------------------------------------ |
-| 13       | CEC Data Line  | Any input/output GPIO (e.g., GPIO26) |
-| 17       | CEC Ground     | GND                                  |
-| 18       | +5V (optional) | 5V                                   |
+| [HDMI Pin](https://en.wikipedia.org/wiki/HDMI)     | Connect to | Microcontroller pin                           |
+| -------- | --------- | --------------------------- |
+| 13 (CEC Data Line)  | => |    Any input/output GPIO (e.g., GPIO26) |
+| 17 (CEC Ground)    | => | Ground                                  |
+| 18  (+5V (optional)) | => | 5V                                   |
 
 > CEC uses 3.3V logic – safe for ESP32/ESP8266 (or any other microcontroller with 3.3V logic).
 

--- a/README.md
+++ b/README.md
@@ -296,22 +296,22 @@ external_components:
 
 hdmi_cec:
   # Pick a GPIO pin that can do both input AND output
-  pin: GPIO26 # Required
+  pin: GPIO10 # Required
   
   # The address can be anything you want. Use 0xF if you only want to listen to the bus and not act like a standard device
   address: 0xE # Required
   
-  # Physical address of the device. In this case: 4.0.0.0 (HDMI4 on the TV)
+  # Physical address of the device. In this case: 4.2.0.0 (The ESP32 is plugged into HDMI 2 on the receiver which is plugged into HDMI4 on the TV)
   # DDC support is not yet implemented, so you'll have to set this manually.
   physical_address: 0x4000 # Required
   
   # The name that will we displayed in the list of devices on your TV/receiver
-  osd_name: "my device" # Optional. Defaults to "esphome"
+  osd_name: "HDMI Bridge" # Optional. Defaults to "esphome"
   
   # By default, promiscuous mode is disabled, so the component only handles directly-address messages (matching
   # the address configured above) and broadcast messages. Enabling promiscuous mode will make the component
   # listen for all messages (both in logs and the on_message triggers)
-  promiscuous_mode: false # Optional. Defaults to false
+  promiscuous_mode: true # Optional. Defaults to false
   
   # By default, monitor mode is disabled, so the component can send messages and acknowledge incoming messages.
   # Enabling monitor mode lets the component act as a passive listener, disabling active manipulation of the CEC bus.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ button:
 
 ---
 
-### 🌐 3. Send CEC Commands via Home Assistant Services
+### 🌐 3. Enable CEC Commands via Home Assistant Services
 
 Under `api:`:
 
@@ -169,7 +169,7 @@ api:
 
 ---
 
-### ☁️ 4. Publish Messages over MQTT ([CEC-O-MATIC](https://www.cec-o-matic.com/) format)
+### ☁️ 4. Publish CEC Messages over MQTT ([CEC-O-MATIC](https://www.cec-o-matic.com/) format)
 
 Under `mqtt:` and `hdmi_cec:`:
 

--- a/README.md
+++ b/README.md
@@ -118,11 +118,14 @@ hdmi_cec:
 
 ```
 
-List of triggers to handle specific commands. Each trigger has the following optional filter parameters:
+You can filter by:
+
   * "source": match messages coming from the specified address
   * "destination": match messages meant for the specified address
   * "opcode": match messages bearing the specified opcode
   * "data": exact-match on message content
+
+If no filter is set, you will catch all messages.
 
 ---
 
@@ -140,7 +143,7 @@ button:
         data: [0x36]
 ```
 
-> More button examples can be found further down.
+> More button examples in the advanced EHPHome configuration example below.
 
 ---
 
@@ -216,7 +219,7 @@ Create a readable message with device names and actions.
           id(cec_translated_message).publish_state(readable);
 ```
 
-#### And add two `text_sensor:` blocks:
+#### And add two `text_sensor:` blocks (required):
 
 ```yaml
 text_sensor:
@@ -326,6 +329,7 @@ hdmi_cec:
           # both "destination" and "data" are templatable
           destination: !lambda return source;
           data: [0x8E, 0x01] # 0x01 => "Menu Deactivated"
+
     - then:
         - mqtt.publish:
             topic: cec_messages
@@ -335,6 +339,7 @@ hdmi_cec:
               frame.push_back((source << 4) | (destination & 0xF));
               frame.insert(frame.end(), data.begin(), data.end());
               return hdmi_cec::bytes_to_string(frame);
+
         - lambda: |-
             id(cec_raw_message).publish_state("...");
             id(cec_translated_message).publish_state("...");

--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ Under `mqtt:` and `hdmi_cec:`:
 
 ```yaml
 mqtt:
-  broker: 'your-mqtt-host.local'
-  username: 'user'
-  password: 'password'
-  discovery: false
+  broker: '192.168.1.100' # insert IP or DNS of your own MQTT broker (e.g. the IP of your HA server)
+  username: !secret mqtt_user # make sure your MQTT username is added to the secrets file in the ESPHome Add-on
+  password: !secret mqtt_password # make sure your MQTT password is added to the secrets file in the ESPHome Add-on
+  discovery: false # if you only want your own MQTT topics
 
 hdmi_cec:
   ...
@@ -327,6 +327,7 @@ hdmi_cec:
     - then:
         - mqtt.publish:
             topic: cec_messages
+            #Payload in CEC-O-Matic format
             payload: !lambda |-
               std::vector<uint8_t> frame;
               frame.push_back((source << 4) | (destination & 0xF));

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ button:
         # "source" can optionally be set, like if you want to spoof another device's address
         destination: 0xF # Broadcast
         data: [0x36] # "Standby" opcode
+
   - platform: template
     name: "Turn TV on"
     on_press:
@@ -370,6 +371,7 @@ button:
         source: 1 # can optionally be set, like if you want to spoof another device's address
         destination: 0
         data: [0x04]
+
   - platform: template
     name: "Turn TV off"
     on_press:
@@ -377,6 +379,7 @@ button:
         source: 1 # can optionally be set, like if you want to spoof another device's address
         destination: 0
         data: [0x36]
+
   - platform: template
     name: "Volume up"
     on_press:
@@ -384,6 +387,7 @@ button:
         # "source" can optionally be set, like if you want to spoof another device's address
         destination: 0x5
         data: [0x44, 0x41]
+
   - platform: template
     name: "Volume down"
     on_press:
@@ -391,6 +395,7 @@ button:
         # "source" can optionally be set, like if you want to spoof another device's address
         destination: 0x5
         data: [0x44, 0x42]
+
   - platform: template
     name: "Mute"
     on_press:
@@ -398,6 +403,7 @@ button:
         # "source" can optionally be set, like if you want to spoof another device's address
         destination: 0x5
         data: [0x44, 0x43]
+
   - platform: template
     name: "Turn on Playback device 1"
     on_press:
@@ -405,6 +411,7 @@ button:
         # "source" can optionally be set, like if you want to spoof another device's address
         destination: 4
         data: [0x44, 0x6D]
+
   - platform: template
     name: "Turn off Playback device 1"
     on_press:
@@ -412,6 +419,7 @@ button:
         # "source" can optionally be set, like if you want to spoof another device's address
         destination: 4
         data: [0x36]
+
   - platform: template
     name: "Playback device 1 home button"
     on_press:
@@ -419,6 +427,7 @@ button:
         # "source" can optionally be set, like if you want to spoof another device's address
         destination: 4
         data: [0x44, 0x09]
+
   - platform: template
     name: "Playback device 1 select/ok"
     on_press:
@@ -426,6 +435,7 @@ button:
         # "source" can optionally be set, like if you want to spoof another device's address
         destination: 4
         data: [0x44, 0x00]
+
   - platform: template
     name: "Playback device 1 exit/back"
     on_press:
@@ -433,6 +443,7 @@ button:
         # "source" can optionally be set, like if you want to spoof another device's address
         destination: 4
         data: [0x44, 0x0D]
+
   - platform: template
     name: "Playback device 1 play/pause"
     on_press:
@@ -440,6 +451,7 @@ button:
         # "source" can optionally be set, like if you want to spoof another device's address
         destination: 4
         data: [0x44, 0x44]
+
   - platform: template
     name: "Turn on Playback device 2"
     on_press:
@@ -447,6 +459,7 @@ button:
         # "source" can optionally be set, like if you want to spoof another device's address
         destination: 8
         data: [0x44, 0x6D]
+
   - platform: template
     name: "Turn off Playback device 2"
     on_press:
@@ -454,6 +467,7 @@ button:
         # "source" can optionally be set, like if you want to spoof another device's address
         destination: 8
         data: [0x36]
+
   - platform: template
     name: "Playback device 2 play/pause"
     on_press:

--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ text_sensor:
     id: cec_translated_message
     update_interval: never
 ```
+> If MQTT is enabled, the text sensor values (raw and translated) will also be sent via MQTT
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,52 +22,87 @@ Make your ESPHome devices speak the (machine) language of your living room with 
 
 - Automatic Physical Address Discovery through E-DDC
 
-## Installation
+## 🚀 Getting Started (Quick Overview)
 
-1. Wire your ESPhome device to an HDMI connector (e.g. an HDMI breakout that can be found on Amazon) as follows :
-    - GPIO pin of your choice -> HDMI pin 13 (CEC)
-    - GND -> HDMI pin 17 (DDC/CEC ground)
-    - _Optional_: wire your board's 5V supply to HDMI pin 18. This is how your TV/switch on the other end knows something is connected.
+### 🪰 Step 1: Connect the hardware
 
-    The CEC bus uses 3.3V logic, so it's perfectly safe for ESP32/ESP8266 devices (or any other microcontroller with 3.3V logic).
+| [HDMI Pin](https://en.wikipedia.org/wiki/HDMI) | Description    | Connect to microcontroller                           |
+| -------- | -------------- | ------------------------------------ |
+| 13       | CEC Data Line  | Any input/output GPIO (e.g., GPIO26) |
+| 17       | CEC Ground     | GND                                  |
+| 18       | +5V (optional) | 5V                                   |
 
-2. In your ESPhome configuration file, add this Git repository as an external component
+> CEC uses 3.3V logic – safe for ESP32/ESP8266 (or any other microcontroller with 3.3V logic).
+
+
+### 🧱 Step 2: Set up ESPHome
+
+* Start by creating your device using **ESPHome Device Builder** (e.g., via Home Assistant’s ESPHome Add-on or ESPHome Web).
+* Once your device is created, click **"Edit"** to access the YAML configuration.
+* (If using an ESP32-C3, it’s recommended to use type: esp-idf)
+
+---
+
+### 📦 Step 3: Add the component
+
+In your ESPhome YAML configuration, add this Git repository as an external component:
 
 ```yaml
 external_components:
   - source: github://Palakis/esphome-hdmi-cec
 ```
 
-3. Setup the HDMI-CEC component
+---
+
+### 🧠 Step 4: Basic HDMI-CEC Setup
+
+Add the `hdmi_cec:` block:
 
 ```yaml
 hdmi_cec:
   # Pick a GPIO pin that can do both input AND output
   pin: GPIO26 # Required
+  
   # The address can be anything you want. Use 0xF if you only want to listen to the bus and not act like a standard device
   address: 0xE # Required
+  
   # Physical address of the device. In this case: 4.0.0.0 (HDMI4 on the TV)
   # DDC support is not yet implemented, so you'll have to set this manually.
   physical_address: 0x4000 # Required
+  
   # The name that will we displayed in the list of devices on your TV/receiver
   osd_name: "my device" # Optional. Defaults to "esphome"
+  
   # By default, promiscuous mode is disabled, so the component only handles directly-address messages (matching
   # the address configured above) and broadcast messages. Enabling promiscuous mode will make the component
   # listen for all messages (both in logs and the on_message triggers)
   promiscuous_mode: false # Optional. Defaults to false
+  
   # By default, monitor mode is disabled, so the component can send messages and acknowledge incoming messages.
   # Enabling monitor mode lets the component act as a passive listener, disabling active manipulation of the CEC bus.
   monitor_mode: false # Optional. Defaults to false
-  # List of triggers to handle specific commands. Each trigger has the following optional filter parameters:
-  # - "source": match messages coming from the specified address
-  # - "destination": match messages meant for the specified address
-  # - "opcode": match messages bearing the specified opcode
-  # - "data": exact-match on message content
-  # Actions called from these triggers is called with "source", "destination" and "data" as parameters
+
+```
+
+You now have a functioning CEC receiver.
+
+---
+
+## ➕ Optional Features
+
+All of the following are optional – include only what you need.
+
+---
+
+### 🔀 1. React to Incoming Messages
+
+Add under `hdmi_cec:`:
+
+```yaml
   on_message:
-    - opcode: 0x36 # opcode for "Standby"
+    - opcode: 0x36  # "Standby"
       then:
-        logger.log: "Got Standby command"
+        logger.log: "Received standby command"
     
     # Respond to "Menu Request" (not required, example purposes only)
     - opcode: 0x8D
@@ -79,123 +114,38 @@ hdmi_cec:
 
 ```
 
-4. (optional) Use the `hdmi_cec.send` action in your ESPHome configuration
+List of triggers to handle specific commands. Each trigger has the following optional filter parameters:
+  * "source": match messages coming from the specified address
+  * "destination": match messages meant for the specified address
+  * "opcode": match messages bearing the specified opcode
+  * "data": exact-match on message content
 
+---
 
-```
+### 🔘 2. Add Template Buttons to Send CEC Commands
+
+Add a `button:` section to create UI buttons:
+
+```yaml
 button:
   - platform: template
-    name: "Turn all HDMI devices off"
+    name: "Turn TV Off"
     on_press:
       hdmi_cec.send:
-        # "source" can optionally be set, like if you want to spoof another device's address
-        destination: 0xF # Broadcast
-        data: [0x36] # "Standby" opcode
-  - platform: template
-    name: "Turn TV on"
-    on_press:
-      hdmi_cec.send:
-        source: 1 # can optionally be set, like if you want to spoof another device's address
-        destination: 0
-        data: [0x04]
-  - platform: template
-    name: "Turn TV off"
-    on_press:
-      hdmi_cec.send:
-        source: 1 # can optionally be set, like if you want to spoof another device's address
         destination: 0
         data: [0x36]
-  - platform: template
-    name: "Volume up"
-    on_press:
-      hdmi_cec.send:
-        # "source" can optionally be set, like if you want to spoof another device's address
-        destination: 0x5
-        data: [0x44, 0x41]
-  - platform: template
-    name: "Volume down"
-    on_press:
-      hdmi_cec.send:
-        # "source" can optionally be set, like if you want to spoof another device's address
-        destination: 0x5
-        data: [0x44, 0x42]
-  - platform: template
-    name: "Mute"
-    on_press:
-      hdmi_cec.send:
-        # "source" can optionally be set, like if you want to spoof another device's address
-        destination: 0x5
-        data: [0x44, 0x43]
-  - platform: template
-    name: "Turn on Playback device 1"
-    on_press:
-      hdmi_cec.send:
-        # "source" can optionally be set, like if you want to spoof another device's address
-        destination: 4
-        data: [0x44, 0x6D]
-  - platform: template
-    name: "Turn off Playback device 1"
-    on_press:
-      hdmi_cec.send:
-        # "source" can optionally be set, like if you want to spoof another device's address
-        destination: 4
-        data: [0x36]
-  - platform: template
-    name: "Playback device 1 home button"
-    on_press:
-      hdmi_cec.send:
-        # "source" can optionally be set, like if you want to spoof another device's address
-        destination: 4
-        data: [0x44, 0x09]
-  - platform: template
-    name: "Playback device 1 select/ok"
-    on_press:
-      hdmi_cec.send:
-        # "source" can optionally be set, like if you want to spoof another device's address
-        destination: 4
-        data: [0x44, 0x00]
-  - platform: template
-    name: "Playback device 1 exit/back"
-    on_press:
-      hdmi_cec.send:
-        # "source" can optionally be set, like if you want to spoof another device's address
-        destination: 4
-        data: [0x44, 0x0D]
-  - platform: template
-    name: "Playback device 1 play/pause"
-    on_press:
-      hdmi_cec.send:
-        # "source" can optionally be set, like if you want to spoof another device's address
-        destination: 4
-        data: [0x44, 0x44]
-  - platform: template
-    name: "Turn on Playback device 2"
-    on_press:
-      hdmi_cec.send:
-        # "source" can optionally be set, like if you want to spoof another device's address
-        destination: 8
-        data: [0x44, 0x6D]
-  - platform: template
-    name: "Turn off Playback device 2"
-    on_press:
-      hdmi_cec.send:
-        # "source" can optionally be set, like if you want to spoof another device's address
-        destination: 8
-        data: [0x36]
-  - platform: template
-    name: "Playback device 2 play/pause"
-    on_press:
-      hdmi_cec.send:
-        # "source" can optionally be set, like if you want to spoof another device's address
-        destination: 8
-        data: [0x44, 0x46]
 ```
 
-5. (optional) Add Services for HomeAssistant
+> More button examples can be found further down.
 
-```
-api
-  ...
+---
+
+### 🌐 3. Send CEC Commands via Home Assistant Services
+
+Under `api:`:
+
+```yaml
+api:
   services:
     - service: hdmi_cec_send
       variables:
@@ -204,207 +154,148 @@ api
       then:
         - hdmi_cec.send:
             destination: !lambda "return static_cast<unsigned char>(cec_destination);"
-            data: !lambda "std::vector<unsigned char> charVector; for (int i : cec_data) { charVector.push_back(static_cast<unsigned char>(i)); } return charVector;"
+            data: !lambda |-
+              std::vector<unsigned char> vec;
+              for (int i : cec_data) vec.push_back(static_cast<unsigned char>(i));
+              return vec;
 ```
 
-6. (optional) Send data via MQTT in CEC-o-matic format
+---
 
-```
+### ☁️ 4. Publish Messages over MQTT ([CEC-O-MATIC](https://www.cec-o-matic.com/) format)
+
+Under `mqtt:` and `hdmi_cec:`:
+
+```yaml
 mqtt:
-  broker: 'homeassistantaddress'
-  username: 'mqtt_user'
-  password: 'mqtt_password'
-  discovery: false # if you only want your own MQTT topics
+  broker: 'your-mqtt-host.local'
+  username: 'user'
+  password: 'password'
+  discovery: false
 
 hdmi_cec:
-  pin: GPIO26
-  address: 0xE
-  physical_address: 0x4000
-  promiscuous_mode: true 
+  ...
+  promiscuous_mode: true
   on_message:
-    # No source, destination or opcode set => catch all messages
     - then:
         mqtt.publish:
           topic: cec_messages
           payload: !lambda |-
-            std::vector<uint8_t> full_frame;
-            full_frame.push_back((source << 4) | (destination & 0xF));
-            full_frame.insert(full_frame.end(), data.begin(), data.end());
-            return hdmi_cec::bytes_to_string(full_frame);       
+            std::vector<uint8_t> frame;
+            frame.push_back((source << 4) | (destination & 0xF));
+            frame.insert(frame.end(), data.begin(), data.end());
+            return hdmi_cec::bytes_to_string(frame);
 ```
 
-8. (optional) Add message decoder and text sensors
+---
 
-```
+### 🔍 5. Decode and Translate CEC Messages (Text Sensor + Decoder)
+
+Create a readable message with device names and actions.
+
+#### Add this under `hdmi_cec:`:
+
+```yaml
   on_message:
-  - then:
-      - lambda: |-
-          // — Build raw frame string —
+    - then:
+        lambda: |-
+          // Build full frame
           std::vector<uint8_t> frame;
           frame.push_back((source << 4) | (destination & 0xF));
           frame.insert(frame.end(), data.begin(), data.end());
           std::string raw = hdmi_cec::bytes_to_string(frame);
           id(cec_raw_message).publish_state(raw);
 
-          // — Helper lambdas —
-          auto formatWithPeriods = [&](uint16_t num) {
-            std::string s = std::to_string(num), out;
-            for (char c : s) { out += c; out += '.'; }
-            if (!out.empty()) out.pop_back();
-            return out;
-          };
-          auto toHex = [&](uint8_t b) {
-            char buf[3]; sprintf(buf, "%02X", b);
-            return std::string(buf);
-          };
-          auto getDeviceName = [&](uint8_t nib) {
-            static const char* names[] = {
-              "TV","Recorder 1","Recorder 2","Tuner 1","Playback 1",
-              "Audio system","Tuner 2","Tuner 3","Playback 2","Recorder 3",
-              "Tuner 4","Playback 3","Reserved 1","Reserved 2","Free Use","Broadcast"
-            };
-            return std::string(names[nib & 0xF]);
-          };
-          // apply your custom names
-          auto applyCustom = [&](const std::string &n) {
-            if (n == "Playback 1")       return std::string("Apple TV");
-            if (n == "Playback 2")       return std::string("PlayStation");
-            if (n == "Audio system")     return std::string("Denon AVR");
-            return n;
-          };
+          // Translate and publish
+          std::string readable = translate_cec_message(source, destination, data);  // replace with your logic
+          id(cec_translated_message).publish_state(readable);
+```
 
-          // — Build device prefix —
-          uint8_t first = frame[0], src = first >> 4, dst = first & 0xF;
-          std::string dev_src = applyCustom(getDeviceName(src));
-          std::string dev_dst = applyCustom(getDeviceName(dst));
-          std::string prefix = dev_src
-            + (dst == 0xF
-                ? " broadcasting:"
-                : " to " + dev_dst + ":");
+#### And add two `text_sensor:` blocks:
 
-          // — Parse opcode & args —
-          uint8_t opcode = frame.size()>1 ? frame[1] : 0x00;
-          uint8_t b2     = frame.size()>2 ? frame[2] : 0x00;
-          uint8_t b3     = frame.size()>3 ? frame[3] : 0x00;
-          uint16_t phys  = (b2 << 8) | b3;
-          int volume     = static_cast<int>(b2) - 2;
-          std::string action;
+```yaml
+text_sensor:
+  - platform: template
+    name: "HDMI CEC Raw Message"
+    id: cec_raw_message
+    update_interval: never
 
-          // — Full translation switch —
-          switch (opcode) {
-              case 0x0D:
-              case 0x04:
-                action = "I am the active source";
-                break;
-              case 0xA0:
-                action = "Routing information";
-                break;
-              case 0x1A:
-                action = std::string("My state is")
-                  + (b2 == 0x01 ? " (On)"
-                  : b2 == 0x02 ? " (Off)" : "");
-                break;
-              case 0x7A:
-                action = "Audio volume (" + std::to_string(volume) + ")";
-                break;
-              case 0x7D:
-                action = "Request audio mode status";
-                break;
-              case 0x7E:
-                action = std::string("Audio mode")
-                  + (b2 == 0x01 ? " (On)"
-                  : b2 == 0x00 ? " (Off)" : "");
-                break;
-              case 0x8C:
-                action = "Requesting vendor ID";
-                break;
-              case 0x8E:
-                action = "CEC routing control command";
-                break;
-              case 0x8F:
-                action = "Requesting power state";
-                break;
-              case 0x9D:
-                action = "Inactive source with physical address ("
-                  + formatWithPeriods(phys) + ")";
-                break;
-              case 0x9E:
-                action = "Reporting CEC version (not translated)";
-                break;
-              case 0x9F:
-                action = "Requesting CEC version";
-                break;
-              case 0x36:
-                action = "Standby";
-                break;
-              case 0x44:
-                action = "Button pressed"
-                  + (b2 == 0x00 ? " (Select)"
-                  : b2 == 0x01 ? " (Up)"
-                  : b2 == 0x02 ? " (Down)"
-                  : b2 == 0x03 ? " (Left)"
-                  : b2 == 0x04 ? " (Right)"
-                  : b2 == 0x41 ? " (Volume up)"
-                  : b2 == 0x42 ? " (Volume down)"
-                  : b2 == 0x46 ? " (Play/Pause)"
-                  : " (Unknown: " + toHex(b2) + toHex(b3) + ")");
-                break;
-              case 0x45:
-                action = "Button released";
-                break;
-              case 0x47:
-                action = "Set OSD display name (not translated)";
-                break;
-              case 0x70:
-                action = "Set active audio source ("
-                  + formatWithPeriods(phys) + ")";
-                break;
-              case 0x71:
-                action = "Requesting system audio mode";
-                break;
-              case 0x72:
-                action = std::string("Set system audio mode")
-                  + (b2 == 0x01 ? " (On)"
-                  : b2 == 0x00 ? " (Off)"
-                  : " (Unknown: " + toHex(b2) + ")");
-                break;
-              case 0x82:
-                action = "Set active source ("
-                  + formatWithPeriods(phys) + ")";
-                break;
-              case 0x83:
-                action = "What is your physical address?";
-                break;
-              case 0x84:
-                action = "My physical address is ("
-                  + formatWithPeriods(phys) + ")";
-                break;
-              case 0x85:
-                action = "Requesting active source";
-                break;
-              case 0x87:
-                action = "Reporting device vendor ID (not translated)";
-                break;
-              case 0x89:
-                action = "Vendor command (not translated)";
-                break;
-              case 0x90:
-                action = "Reporting power status"
-                  + (b2 == 0x00 ? " (Power On)"
-                  : b2 == 0x01 ? " (Standby)"
-                  : b2 == 0x02 ? " (In transition from Standby to On)"
-                  : b2 == 0x03 ? " (Power Off)"
-                  : " (Unknown: " + toHex(b2) + ")");
-                break;
-              default:
-                action = "Unknown action (0x" + toHex(opcode) + ")";
-                break;
-            }
+  - platform: template
+    name: "HDMI CEC Translated Message"
+    id: cec_translated_message
+    update_interval: never
+```
 
-          // — Publish the human-readable translation —
-          std::string translated = prefix + " " + action;
-          id(cec_translated_message).publish_state(translated);
+> You can use the full decoder example from this repo for more advanced parsing and custom naming.
 
+---
+
+## 🧪 Advanced Example (All Features Combined)
+
+Here’s a full YAML snippet that includes all optional features together:
+
+```yaml
+external_components:
+  - source: github://Palakis/esphome-hdmi-cec
+
+esphome:
+  name: hdmi_cec_bridge
+  platform: ESP32
+  board: esp32-c3-devkitm-1
+  build:
+    type: esp-idf
+
+wifi:
+  ssid: "..."
+  password: "..."
+
+mqtt:
+  broker: 192.168.1.100
+  username: mqtt_user
+  password: mqtt_password
+  discovery: false
+
+api:
+  services:
+    - service: hdmi_cec_send
+      variables:
+        cec_destination: int
+        cec_data: int[]
+      then:
+        - hdmi_cec.send:
+            destination: !lambda "return static_cast<unsigned char>(cec_destination);"
+            data: !lambda |-
+              std::vector<unsigned char> vec;
+              for (int i : cec_data) vec.push_back(static_cast<unsigned char>(i));
+              return vec;
+
+hdmi_cec:
+  pin: GPIO26
+  address: 0xE
+  physical_address: 0x4000
+  osd_name: "HDMI Bridge"
+  promiscuous_mode: true
+  monitor_mode: false
+  on_message:
+    - then:
+        - mqtt.publish:
+            topic: cec_messages
+            payload: !lambda |-
+              std::vector<uint8_t> frame;
+              frame.push_back((source << 4) | (destination & 0xF));
+              frame.insert(frame.end(), data.begin(), data.end());
+              return hdmi_cec::bytes_to_string(frame);
+        - lambda: |-
+            id(cec_raw_message).publish_state("...");
+            id(cec_translated_message).publish_state("...");
+
+button:
+  - platform: template
+    name: "Power Off All Devices"
+    on_press:
+      hdmi_cec.send:
+        destination: 0xF
+        data: [0x36]
 
 text_sensor:
   - platform: template
@@ -418,17 +309,16 @@ text_sensor:
     update_interval: never
 ```
 
+---
 
+## ✅ Compatibility
 
+| Platform  | Supported | Notes                             |
+| --------- | --------- | --------------------------------- |
+| ESP32     | ✅         | Fully supported                   |
+| ESP32-C3  | ✅         | Use `type: esp-idf` (recommended) |
+| ESP8266   | ✅         | Tested and works                  |
+| RP2040    | ✅         | Tested and works                  |
+| LibreTiny | ❌         | Not supported                     |
 
-## Compatibility
-
-- ESP32: ✅ **tested, works**
-- ESP8266: ✅ **tested, works**
-- RP2040: ✅ **tested, works**
-- LibreTiny: ❌ **not supported**
-  - I don't have any LibreTiny device at hand. Feel free to run your own tests and report back your findings.
-
-## Acknowledgements
-
-- [johnboiles' `esphome-hdmi-cec` component](https://github.com/johnboiles/esphome-hdmi-cec) has been the inspiration and starting point of this project.
+---

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ All of the following are optional – include only what you need.
 Add under `hdmi_cec:`:
 
 ```yaml
+hdmi_cec:
+  ...
   on_message:
     - opcode: 0x36  # "Standby"
       then:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Make your ESPHome devices speak the (machine) language of your living room with 
 
 Connect the microcontroller to an HDMI connector (HDMI connectors and breakout boards can be found on Amazon and AliExpress)
 
-| [HDMI Pin](https://en.wikipedia.org/wiki/HDMI) | Description    | Connect to microcontroller                           |
+| [HDMI Pin](https://en.wikipedia.org/wiki/HDMI) | Description    | Connect to microcontroller pin                           |
 | -------- | -------------- | ------------------------------------ |
 | 13       | CEC Data Line  | Any input/output GPIO (e.g., GPIO26) |
 | 17       | CEC Ground     | GND                                  |


### PR DESCRIPTION
Updated README for clarity and beginner-friendliness. Added examples and explanations for YAML configuration, including CEC message decoder text sensors, more button examples and MQTT.

The suggested changes are based on the questions I had when I first started using this component and the questions I received from others when I shared the project in various Facebook groups. Hopefully this will enable even more people to benefit from this awesome component.