### PR TITLE
fix cec decoder after change of operand <None>

### DIFF
--- a/components/hdmi_cec/cec_decoder.cpp
+++ b/components/hdmi_cec/cec_decoder.cpp
@@ -451,6 +451,7 @@ std::string Decoder::decode() {
   result += std::string("<") + it->second.name + ">";
   // operand fields
   length_ = 0;  // currently accumulated length of text of operands
+  line_[length_] = 0;  // initialise operand text to empty string
   offset_ = 2;  // location in frame of first operand to decode
   OperandDecode_f f = it->second.decode_f;
   (this->*f)();


### PR DESCRIPTION
Testing the integration of the `cec_decoder`  revealed that the latest edit of `template<> bool Decoder::do_operand<Decoder::None>() { return false; }` did introduce a bug :-(
Sorry that I  initially thought that this was just safe...

Here is a one-line fix.

Jos