### PR TITLE
Add documentation to update the logical or physical address at run-time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,53 @@ text_sensor:
 
 ---
 
+### ✎6. Runtime configuration of the physical and logical address of HDMI
+
+If you want the logical address and the physical address to be configurable, you can add input number fields.
+
+```yaml
+number:
+  - platform: template
+    optimistic: true
+    entity_category: config
+    name: HDMI Logical address
+    step: 1
+    min_value: 0x1 # Recording device 1
+    max_value: 0xb # Playback device 3
+    icon: "mdi:video-input-hdmi"
+    restore_value: true
+    on_value:
+      - then:
+          lambda: |-
+            id(hdmicec)->set_address(x);
+  - platform: template
+    optimistic: true
+    entity_category: config
+    name: HDMI Physical address
+    id: hdmi_phys_addr
+    disabled_by_default: true
+    step: 1
+    min_value: 0x1000
+    max_value: 0x4fff # Assuming up to 4 HDMI ports
+    initial_value: 0x1001 # Avoid conflict with any existing device.
+    mode: box
+    icon: "mdi:hdmi-port"
+    restore_value: true
+    on_value:
+      - lambda: |-
+          id(hdmicec)->set_physical_address(x);
+
+hdmi_cec:
+  id: hdmicec
+  ...
+```
+You may also consider adding 2 separate number fields - HDMI port (1-4) and adjustment (0-15) to calculate the physical address as  
+`physical address = (port * 0x1000 + adjustment)` (0x1000-0x100f, 0x4000-0x400f)
+The adjustment field is used to avoid conflicts with any existing device on those ports.
+Note that the physical_address and address fields still need to be specified in the `hdmi_cec:` section.
+
+---
+
 ## 🧪 Advanced Example (All Features Combined)
 
 Here’s a full YAML snippet that includes all optional features together:


### PR DESCRIPTION
We can add a number input in home assistant and set the physical/logical addresses from it.

You can also calculate the physical address using the port and the adjustment logic as below:

```yaml
number:
  - platform: template
    optimistic: true
    entity_category: config
    name: HDMI Logical address
    step: 1
    min_value: 0x1
    max_value: 0xd
    icon: "mdi:video-input-hdmi"
    restore_value: true
    on_value:
      - then:
          lambda: |-
            id(hdmicec)->set_address(x);
  - platform: template
    optimistic: true
    entity_category: config
    disabled_by_default: true
    id: hdmi_phys_addr
    name: HDMI Physical address
    step: 1
    min_value: 0x1000
    max_value: 0x4fff
    mode: box
    icon: "mdi:hdmi-port"
    restore_value: true
    on_value:
      - lambda: |-
          id(hdmicec)->set_physical_address(x);
      - if:
          condition:
            - lambda: |-
                    return (id(hdmi_phys_addr_adjustment).state + (0x1000 * id(hdmi_port).state) != id(hdmi_phys_addr).state);
          then:
          - number.set:
              id: hdmi_port
              value: !lambda |-
                    return int(x / 0x1000);
          - number.set:
              id: hdmi_phys_addr_adjustment
              value: !lambda |-
                    return int(x) & 0xf;
  - platform: template
    optimistic: true
    entity_category: config
    id: hdmi_port
    name: HDMI port number
    min_value: 1
    max_value: 4
    step: 1
    icon: "mdi:hdmi-port"
    on_value:
      - if:
          condition:
            - lambda: |-
                     return (id(hdmi_phys_addr_adjustment).state + (0x1000 * id(hdmi_port).state) != id(hdmi_phys_addr).state);
          then:
          - number.set:
              id: hdmi_phys_addr
              value: !lambda |-
                    return (x * 0x1000) + id(hdmi_phys_addr_adjustment).state;

  - platform: template
    optimistic: true
    entity_category: config
    id: hdmi_phys_addr_adjustment
    disabled_by_default: true
    name: HDMI Physical address adjustment
    step: 1
    min_value: 0
    max_value: 15
    initial_value: 1
    on_value:
      - if:
          condition:
            - lambda: |-
                     return id(hdmi_phys_addr_adjustment).state + (0x1000 * id(hdmi_port).state) != id(hdmi_phys_addr).state;
          then:
          - number.set:
              id: hdmi_phys_addr
              value: !lambda |-
                    return x + (0x1000 * id(hdmi_port).state);
```

I have tested this on waveshare esp32c6-zero.