### PR TITLE
Fix compilation on esphome 2025.11.0

### DIFF
--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -163,7 +163,7 @@ public:
   TEMPLATABLE_VALUE(uint8_t, destination)
   TEMPLATABLE_VALUE(std::vector<uint8_t>, data)
 
-  void play(Ts... x) override {
+  void play(const Ts&... x) override {
     auto source_address = source_.has_value() ? source_.value(x...) : parent_->address();
     auto destination_address = destination_.value(x...);
     auto data = data_.value(x...);


### PR DESCRIPTION
Hello,

This change fix my issue 
```
Compiling .pioenvs/tv-gateway/lib177/libsodium/crypto_stream/salsa20/xmm6int/salsa20_xmm6int-avx2.o
In file included from src/esphome/components/hdmi_cec/cec_decoder.h:9,
                 from src/esphome.h:36,
                 from src/main.cpp:3:
src/esphome/components/hdmi_cec/hdmi_cec.h: In instantiation of 'class esphome::hdmi_cec::SendAction<long int, const esphome::FixedVector<long int>&>':
/config/esphome/tv-gateway.yaml:2234:99:   required from here
src/esphome/components/hdmi_cec/hdmi_cec.h:166:8: error: 'void esphome::hdmi_cec::SendAction<Ts>::play(Ts ...) [with Ts = {long int, const esphome::FixedVector<long int>&}]' marked 'override', but does not override
  166 |   void play(Ts... x) override {
      |        ^~~~
/config/esphome/tv-gateway.yaml: In function 'void setup()':
/config/esphome/tv-gateway.yaml:2234:99: error: invalid new-expression of abstract class type 'esphome::hdmi_cec::SendAction<long int, const esphome::FixedVector<long int>&>'
src/esphome/components/hdmi_cec/hdmi_cec.h:159:32: note:   because the following virtual functions are pure within 'esphome::hdmi_cec::SendAction<long int, const esphome::FixedVector<long int>&>':
  159 | template<typename... Ts> class SendAction : public Action<Ts...> {
      |                                ^~~~~~~~~~
In file included from src/esphome/components/binary_sensor/filter.h:3,
                 from src/esphome/components/binary_sensor/binary_sensor.h:5,
                 from src/esphome/core/application.h:30,
                 from src/esphome/components/api/api_frame_helper.h:13,
                 from src/esphome/components/api/api_connection.h:5,
                 from src/esphome.h:3:
src/esphome/core/automation.h:225:16: note:     'void esphome::Action<Ts>::play(const Ts& ...) [with Ts = {long int, const esphome::FixedVector<long int>&}]'
  225 |   virtual void play(const Ts &...x) = 0;
      |                ^~~~
src/esphome/components/hdmi_cec/hdmi_cec.h: In instantiation of 'class esphome::hdmi_cec::SendAction<unsigned char, unsigned char, std::vector<unsigned char, std::allocator<unsigned char> > >':
/config/esphome/tv-gateway.yaml:138:102:   required from here
  138 | ##########################
      |                                                                                                      ^
src/esphome/components/hdmi_cec/hdmi_cec.h:166:8: error: 'void esphome::hdmi_cec::SendAction<Ts>::play(Ts ...) [with Ts = {unsigned char, unsigned char, std::vector<unsigned char, std::allocator<unsigned char> >}]' marked 'override', but does not override
  166 |   void play(Ts... x) override {
      |        ^~~~
/config/esphome/tv-gateway.yaml:138:102: error: invalid new-expression of abstract class type 'esphome::hdmi_cec::SendAction<unsigned char, unsigned char, std::vector<unsigned char, std::allocator<unsigned char> > >'
  138 | ##########################
      |                                                                                                      ^
src/esphome/components/hdmi_cec/hdmi_cec.h:159:32: note:   because the following virtual functions are pure within 'esphome::hdmi_cec::SendAction<unsigned char, unsigned char, std::vector<unsigned char, std::allocator<unsigned char> > >':
  159 | template<typename... Ts> class SendAction : public Action<Ts...> {
      |                                ^~~~~~~~~~
src/esphome/core/automation.h:225:16: note:     'void esphome::Action<Ts>::play(const Ts& ...) [with Ts = {unsigned char, unsigned char, std::vector<unsigned char, std::allocator<unsigned char> >}]'
  225 |   virtual void play(const Ts &...x) = 0;
      |                ^~~~
/config/esphome/tv-gateway.yaml:238:102: error: invalid new-expression of abstract class type 'esphome::hdmi_cec::SendAction<unsigned char, unsigned char, std::vector<unsigned char, std::allocator<unsigned char> > >'
  238 |           data: [0x87, 0x0f, 0x42, 0x3f] #VENDOR ID 999999
      |                                                                                                      ^
/config/esphome/tv-gateway.yaml:245:102: error: invalid new-expression of abstract class type 'esphome::hdmi_cec::SendAction<unsigned char, unsigned char, std::vector<unsigned char, std::allocator<unsigned char> > >'
  245 | 
      |                                                                                                      ^
Compiling .pioenvs/tv-gateway/lib177/libsodium/crypto_stream/salsa20/xmm6int/salsa20_xmm6int-sse2.o
Compiling .pioenvs/tv-gateway/lib177/libsodium/crypto_verify/verify.o
```