### PR TITLE
Update SendAction::play signature for ESPHome 2025.11 compatibility

### DIFF
--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -163,7 +163,7 @@ public:
   TEMPLATABLE_VALUE(uint8_t, destination)
   TEMPLATABLE_VALUE(std::vector<uint8_t>, data)
 
-  void play(Ts... x) override {
+  void play(const Ts &... x) override {
     auto source_address = source_.has_value() ? source_.value(x...) : parent_->address();
     auto destination_address = destination_.value(x...);
     auto data = data_.value(x...);


### PR DESCRIPTION
This small patch updates the HDMI-CEC component to match a recent ESPHome API change.

ESPHome 2025.11 updated the base Action::play method to use:

`void play(const Ts &... x);`


The previous implementation in SendAction used:

`void play(Ts... x) override;`


This caused the component to become abstract and fail to build with errors such as:

```
error: 'play' marked 'override' but does not override
error: invalid new-expression of abstract class type
```


This PR updates the signature to match the new ESPHome API.
No behavioral changes — just restored compatibility.

If you prefer this change structured differently, I’m happy to adjust!

Thanks for maintaining this project.