### PR TITLE
Enable auto-scanning for logical address, and implement bus scanning with device lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Make your ESPHome devices speak the (machine) language of your living room with 
       - _"Give OSD Name"_
 - Send CEC commands
     - Built-in `hdmi_cec.send` action
+- Bus scanning & device discovery
+    - Automatic scan on startup with configurable delay
+    - On-demand scanning via `hdmi_cec.scan_bus` action
+    - Device registry with OSD name, physical address, vendor ID, power status, and more
+    - Query devices by logical address, OSD name, physical address, or vendor/type
+    - Passive registry updates from broadcast messages
 
 ### To-do list
 
@@ -262,6 +268,93 @@ hdmi_cec:
           payload: !lambda |-
             return hdmi_cec::Frame(source, destination, data).to_string(true);
 ```
+
+---
+
+### 6. Bus Scanning & Device Discovery
+
+The component can scan the CEC bus to discover connected devices and collect their information. Scanning is non-blocking and runs asynchronously in the background.
+
+#### Configuration
+
+```yaml
+hdmi_cec:
+  id: cec
+  pin: GPIO26
+  physical_address: 0x4000
+  device_type: playback_device
+
+  # Scan the bus on startup (default: true)
+  scan_on_boot: true
+
+  # Delay before the initial scan, to let other devices finish negotiation (default: 3s)
+  scan_boot_delay: 3s
+
+  # Trigger when a scan completes
+  on_scan_complete:
+    - then:
+        - lambda: |-
+            for (uint8_t i = 0; i < 15; i++) {
+              if (id(cec).seen_on_last_scan(i)) {
+                auto &dev = id(cec).get_device_info(i);
+                ESP_LOGI("cec", "Device 0x%X: type=%d phys=%04X name='%s' vendor=%06X power=%d",
+                         i, dev.device_type, dev.physical_address,
+                         dev.osd_name.c_str(), dev.vendor_id, dev.power_status);
+              }
+            }
+```
+
+#### Triggering a scan manually
+
+Use the `hdmi_cec.scan_bus` action from any automation:
+
+```yaml
+button:
+  - platform: template
+    name: "Scan CEC Bus"
+    on_press:
+      - hdmi_cec.scan_bus
+```
+
+#### Querying the device registry from lambdas
+
+The scan populates a per-device registry (logical addresses 0-14) with the following fields:
+
+| Field | Type | Default (unknown) | Source |
+|-------|------|--------------------|--------|
+| `device_type` | `uint8_t` | `0xFF` | Report Physical Address |
+| `physical_address` | `uint16_t` | `0xFFFF` | Report Physical Address |
+| `osd_name` | `std::string` | `""` | Set OSD Name |
+| `vendor_id` | `uint32_t` | `0xFFFFFF` | Device Vendor ID |
+| `power_status` | `uint8_t` | `0xFF` | Report Power Status |
+| `cec_version` | `uint8_t` | `0xFF` | CEC Version |
+| `active_source` | `bool` | `false` | Active Source broadcast |
+| `last_seen_ms` | `uint32_t` | `0` | Any response from device |
+
+Available query methods:
+
+```cpp
+// Get info for a specific logical address
+auto &dev = id(cec).get_device_info(0);  // TV is usually address 0
+
+// Check if a device was seen on the most recent scan
+bool tv_present = id(cec).seen_on_last_scan(0);
+
+// Find a device by OSD name
+auto addr = id(cec).find_address_by_osd_name("Samsung TV");
+if (addr.has_value()) { /* use *addr */ }
+
+// Find a device by physical address
+auto addr = id(cec).find_address_by_physical_address(0x1000);
+
+// Find a device by vendor ID and device type (useful for devices without OSD names)
+auto addr = id(cec).find_address_by_vendor_and_type(0x000678, 0x04);  // e.g., Panasonic playback device
+
+// Check if a scan is currently running
+bool scanning = id(cec).is_scanning();
+```
+
+The registry is also updated passively from broadcast messages (Report Physical Address, Device Vendor ID, Active Source) even outside of active scans.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -67,22 +67,22 @@ Add the `hdmi_cec:` block:
 hdmi_cec:
   # Pick a GPIO pin that can do both input AND output
   pin: GPIO26 # Required
-  
-  # The address can be anything you want. Use 0xF if you only want to listen to the bus and not act like a standard device
-  address: 0xE # Required
-  
+
+  # The type of CEC device to present as. Used for automatic logical address negotiation.
+  # Options: tv, recording_device, tuner, playback_device, audio_system, other
+  # device_type: playback_device # Optional. Defaults to "other"
+
   # Physical address of the device. In this case: 4.0.0.0 (HDMI4 on the TV)
   # DDC support is not yet implemented, so you'll have to set this manually.
   physical_address: 0x4000 # Required
-  
+
   # The name that will be displayed in the list of devices on your TV/receiver
   osd_name: "my device" # Optional. Defaults to "esphome"
-  
-  # By default, promiscuous mode is disabled, so the component only handles directly-address messages (matching
-  # the address configured above) and broadcast messages. Enabling promiscuous mode will make the component
+
+  # By default, promiscuous mode is disabled, so the component only handles directly-addressed messages and broadcast messages. Enabling promiscuous mode will make the component
   # listen for all messages (both in logs and the on_message triggers)
   promiscuous_mode: false # Optional. Defaults to false
-  
+
   # By default, monitor mode is disabled, so the component can send messages and acknowledge incoming messages.
   # Enabling monitor mode lets the component act as a passive listener, disabling active manipulation of the CEC bus.
   monitor_mode: false # Optional. Defaults to false
@@ -90,6 +90,14 @@ hdmi_cec:
 ```
 
 You now have a functioning CEC receiver.
+
+> **Note on `address` (backward-compatibility only):** The `address` option still exists for backward
+> compatibility, allowing you to hard-code a logical address (e.g., `address: 0xE`). However, this is
+> **strongly discouraged** because it bypasses the CEC bus negotiation protocol: if another device on
+> the bus already uses the same address, both devices will malfunction (garbled commands, missed
+> messages, or devices disappearing from the TV's device list). Using `device_type` lets the component
+> negotiate a free address automatically at startup, which is the correct behavior per the HDMI-CEC
+> specification. A compile-time warning is emitted when `address` is used.
 
 ---
 
@@ -316,22 +324,22 @@ external_components:
 hdmi_cec:
   # Pick a GPIO pin that can do both input AND output
   pin: GPIO10 # Required
-  
-  # The address can be anything you want. Use 0xF if you only want to listen to the bus and not act like a standard device
-  address: 0xE # Required
-  
+
+  # The type of CEC device to present as. Used for automatic logical address negotiation.
+  # Options: tv, recording_device, tuner, playback_device, audio_system, other
+  device_type: playback_device # Optional. Defaults to "other"
+
   # Physical address of the device. In this case: 4.2.0.0 (The ESP32 is plugged into HDMI 2 on the receiver which is plugged into HDMI4 on the TV)
   # DDC support is not yet implemented, so you'll have to set this manually.
   physical_address: 0x4200 # Required
-  
+
   # The name that will be displayed in the list of devices on your TV/receiver
   osd_name: "HDMI Bridge" # Optional. Defaults to "esphome"
-  
-  # By default, promiscuous mode is disabled, so the component only handles directly addressed messages (matching
-  # the address configured above) and broadcast messages. Enabling promiscuous mode will make the component
+
+  # By default, promiscuous mode is disabled, so the component only handles directly-addressed messages and broadcast messages. Enabling promiscuous mode will make the component
   # listen for all messages (both in logs and the on_message triggers)
   promiscuous_mode: true # Optional. Defaults to false
-  
+
   # By default, monitor mode is disabled, so the component can send messages and acknowledge incoming messages.
   # Enabling monitor mode lets the component act as a passive listener, disabling active manipulation of the CEC bus.
   monitor_mode: false # Optional. Defaults to false

--- a/components/hdmi_cec/__init__.py
+++ b/components/hdmi_cec/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins, automation
@@ -5,6 +7,8 @@ from esphome.const import (
     CONF_ID,
     CONF_TRIGGER_ID
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 CODEOWNERS = ["@Palakis"]
 
@@ -16,12 +20,22 @@ CONF_MONITOR_MODE = "monitor_mode"
 CONF_DECODE_MESSAGES = "decode_messages"
 CONF_OSD_NAME = "osd_name"
 CONF_ON_MESSAGE = "on_message"
+CONF_DEVICE_TYPE = "device_type"
 
 CONF_SOURCE = "source"
 CONF_DESTINATION = "destination"
 CONF_OPCODE = "opcode"
 CONF_DATA = "data"
 CONF_PARENT = "parent"
+
+DEVICE_TYPES = {
+    "tv": 0x00,
+    "recording_device": 0x01,
+    "tuner": 0x03,
+    "playback_device": 0x04,
+    "audio_system": 0x05,
+    "other": 0xFF,
+}
 
 def validate_data_array(value):
     if isinstance(value, list):
@@ -55,26 +69,36 @@ SendAction = hdmi_cec_ns.class_(
     "SendAction", automation.Action
 )
 
-CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(HDMICEC),
-        cv.Required(CONF_PIN): pins.internal_gpio_output_pin_schema,
-        cv.Required(CONF_ADDRESS): cv.int_range(min=0, max=15),
-        cv.Required(CONF_PHYSICAL_ADDRESS): cv.uint16_t,
-        cv.Optional(CONF_PROMISCUOUS_MODE, False): cv.boolean,
-        cv.Optional(CONF_MONITOR_MODE, False): cv.boolean,
-        cv.Optional(CONF_DECODE_MESSAGES, True): cv.boolean,
-        cv.Optional(CONF_OSD_NAME, "esphome"): validate_osd_name,
-        cv.Optional(CONF_ON_MESSAGE): automation.validate_automation(
-            {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MessageTrigger),
-                cv.Optional(CONF_SOURCE): cv.int_range(min=0, max=15),
-                cv.Optional(CONF_DESTINATION): cv.int_range(min=0, max=15),
-                cv.Optional(CONF_OPCODE): cv.uint8_t,
-                cv.Optional(CONF_DATA): validate_data_array
-            }
-        )
-    }
+def validate_address_config(config):
+    has_device_type = CONF_DEVICE_TYPE in config or CONF_ADDRESS not in config
+    if has_device_type and config.get(CONF_MONITOR_MODE, False):
+        raise cv.Invalid("'device_type' cannot be used with 'monitor_mode' (passive devices don't negotiate)")
+    return config
+
+CONFIG_SCHEMA = cv.All(
+    cv.COMPONENT_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(HDMICEC),
+            cv.Required(CONF_PIN): pins.internal_gpio_output_pin_schema,
+            cv.Optional(CONF_ADDRESS): cv.int_range(min=0, max=15),
+            cv.Required(CONF_PHYSICAL_ADDRESS): cv.uint16_t,
+            cv.Optional(CONF_DEVICE_TYPE): cv.enum(DEVICE_TYPES, lower=True),
+            cv.Optional(CONF_PROMISCUOUS_MODE, False): cv.boolean,
+            cv.Optional(CONF_MONITOR_MODE, False): cv.boolean,
+            cv.Optional(CONF_DECODE_MESSAGES, True): cv.boolean,
+            cv.Optional(CONF_OSD_NAME, "esphome"): validate_osd_name,
+            cv.Optional(CONF_ON_MESSAGE): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MessageTrigger),
+                    cv.Optional(CONF_SOURCE): cv.int_range(min=0, max=15),
+                    cv.Optional(CONF_DESTINATION): cv.int_range(min=0, max=15),
+                    cv.Optional(CONF_OPCODE): cv.uint8_t,
+                    cv.Optional(CONF_DATA): validate_data_array
+                }
+            )
+        }
+    ),
+    validate_address_config,
 )
 
 async def to_code(config):
@@ -87,7 +111,19 @@ async def to_code(config):
     cec_pin_ = await cg.gpio_pin_expression(config[CONF_PIN])
     cg.add(var.set_pin(cec_pin_))
 
-    cg.add(var.set_address(config[CONF_ADDRESS]))
+    if CONF_ADDRESS in config:
+        _LOGGER.warning(
+            "hdmi_cec: Manually setting 'address' is deprecated and bypasses logical "
+            "address auto-negotiation. This can cause conflicts with other CEC devices "
+            "on the bus. Please remove 'address' and use 'device_type' instead."
+        )
+        cg.add(var.set_address(config[CONF_ADDRESS]))
+    else:
+        cg.add(var.set_address(0x0F))  # Unregistered until negotiation
+
+    if CONF_ADDRESS not in config:
+        cg.add(var.set_device_type(config.get(CONF_DEVICE_TYPE, DEVICE_TYPES["other"])))
+
     cg.add(var.set_physical_address(config[CONF_PHYSICAL_ADDRESS]))
     cg.add(var.set_promiscuous_mode(config[CONF_PROMISCUOUS_MODE]))
     cg.add(var.set_monitor_mode(config[CONF_MONITOR_MODE]))

--- a/components/hdmi_cec/__init__.py
+++ b/components/hdmi_cec/__init__.py
@@ -27,6 +27,9 @@ CONF_DESTINATION = "destination"
 CONF_OPCODE = "opcode"
 CONF_DATA = "data"
 CONF_PARENT = "parent"
+CONF_SCAN_ON_BOOT = "scan_on_boot"
+CONF_SCAN_BOOT_DELAY = "scan_boot_delay"
+CONF_ON_SCAN_COMPLETE = "on_scan_complete"
 
 DEVICE_TYPES = {
     "tv": 0x00,
@@ -68,6 +71,12 @@ MessageTrigger = hdmi_cec_ns.class_(
 SendAction = hdmi_cec_ns.class_(
     "SendAction", automation.Action
 )
+ScanBusAction = hdmi_cec_ns.class_(
+    "ScanBusAction", automation.Action
+)
+ScanCompleteTrigger = hdmi_cec_ns.class_(
+    "ScanCompleteTrigger", automation.Trigger.template()
+)
 
 def validate_address_config(config):
     has_device_type = CONF_DEVICE_TYPE in config or CONF_ADDRESS not in config
@@ -87,6 +96,13 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_MONITOR_MODE, False): cv.boolean,
             cv.Optional(CONF_DECODE_MESSAGES, True): cv.boolean,
             cv.Optional(CONF_OSD_NAME, "esphome"): validate_osd_name,
+            cv.Optional(CONF_SCAN_ON_BOOT, default=True): cv.boolean,
+            cv.Optional(CONF_SCAN_BOOT_DELAY, default="3s"): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_ON_SCAN_COMPLETE): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ScanCompleteTrigger),
+                }
+            ),
             cv.Optional(CONF_ON_MESSAGE): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MessageTrigger),
@@ -132,6 +148,13 @@ async def to_code(config):
     osd_name_bytes = [x for x in osd_name_bytes] # convert byte array to int array
     osd_name_bytes = cg.std_vector.template(cg.uint8)(osd_name_bytes)
     cg.add(var.set_osd_name_bytes(osd_name_bytes))
+
+    cg.add(var.set_scan_on_boot(config[CONF_SCAN_ON_BOOT]))
+    cg.add(var.set_scan_boot_delay(config[CONF_SCAN_BOOT_DELAY]))
+
+    for conf in config.get(CONF_ON_SCAN_COMPLETE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
 
     for conf in config.get(CONF_ON_MESSAGE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
@@ -188,3 +211,14 @@ async def send_action_to_code(config, action_id, template_args, args):
     cg.add(var.set_data(data_template_))
 
     return var
+
+@automation.register_action(
+    "hdmi_cec.scan_bus",
+    ScanBusAction,
+    {
+        cv.GenerateID(CONF_PARENT): cv.use_id(HDMICEC),
+    }
+)
+async def scan_bus_action_to_code(config, action_id, template_args, args):
+    parent = await cg.get_variable(config[CONF_PARENT])
+    return cg.new_Pvariable(action_id, template_args, parent)

--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -65,17 +65,22 @@ inline void IRAM_ATTR HDMICEC::set_pin_output_low() {
 }
 
 void HDMICEC::setup() {
-  this->pin_->setup();  
+  this->pin_->setup();
   isr_pin_ = pin_->to_isr();
   frames_queue_.reset();
   pin_->attach_interrupt(HDMICEC::gpio_intr_, this, gpio::INTERRUPT_ANY_EDGE);
   set_pin_input_high();
+
+  if (negotiation_needed_) {
+    negotiate_address_();
+    broadcast_physical_address_();
+  }
 }
 
 void HDMICEC::dump_config() {
   ESP_LOGCONFIG(TAG, "HDMI-CEC");
   LOG_PIN("  pin: ", pin_);
-  ESP_LOGCONFIG(TAG, "  address: %x", address_);
+  ESP_LOGCONFIG(TAG, "  address: 0x%X", address_);
   ESP_LOGCONFIG(TAG, "  promiscuous mode: %s", (promiscuous_mode_ ? "yes" : "no"));
   ESP_LOGCONFIG(TAG, "  monitor mode: %s", (monitor_mode_ ? "yes" : "no"));
 }
@@ -163,6 +168,97 @@ uint8_t logical_address_to_device_type(uint8_t logical_address) {
     default:
       return 0x04; // "Playback Device"
   }
+}
+
+static const std::vector<uint8_t> &device_type_to_candidate_addresses(uint8_t device_type) {
+  static const std::vector<uint8_t> TV_ADDRS = {0x0};
+  static const std::vector<uint8_t> RECORDING_ADDRS = {0x1, 0x2, 0x9};
+  static const std::vector<uint8_t> TUNER_ADDRS = {0x3, 0x6, 0x7, 0xA};
+  static const std::vector<uint8_t> PLAYBACK_ADDRS = {0x4, 0x8, 0xB};
+  static const std::vector<uint8_t> AUDIO_ADDRS = {0x5};
+  // Reserved addresses 0xC-0xE: not assigned to any standard device type,
+  // so least likely to collide with real CEC hardware.
+  static const std::vector<uint8_t> OTHER_ADDRS = {0xE, 0xD, 0xC};
+  static const std::vector<uint8_t> EMPTY = {};
+
+  switch (device_type) {
+    case 0x00: return TV_ADDRS;
+    case 0x01: return RECORDING_ADDRS;
+    case 0x03: return TUNER_ADDRS;
+    case 0x04: return PLAYBACK_ADDRS;
+    case 0x05: return AUDIO_ADDRS;
+    case 0xFF: return OTHER_ADDRS;
+    default: return EMPTY;
+  }
+}
+
+bool HDMICEC::test_address_available_(uint8_t candidate_address) {
+  // Send a polling message: header-only frame where source == destination
+  Frame frame(candidate_address, candidate_address, {});
+
+  // Wait for signal free time (5 bit periods for new initiator)
+  int32_t delay = 5 * TOTAL_BIT_US + std::max(last_sent_us_, last_falling_edge_us_) - micros();
+  if (delay > 0) {
+    delay_microseconds_safe(delay);
+  }
+
+  // For a directed message (non-broadcast), send_frame_ returns:
+  //   Success if ACKed (another device has this address)
+  //   NoAck if not ACKed (address is free)
+  auto result = send_frame_(frame, false);
+  last_sent_us_ = micros();
+
+  if (result == SendResult::NoAck) {
+    ESP_LOGD(TAG, "Address 0x%X is free", candidate_address);
+    return true;
+  }
+  ESP_LOGD(TAG, "Address 0x%X is taken (result=%d)", candidate_address, (int) result);
+  return false;
+}
+
+void HDMICEC::negotiate_address_() {
+  if (!device_type_.has_value()) {
+    return;
+  }
+
+  ESP_LOGI(TAG, "Starting CEC logical address negotiation");
+
+  address_ = 0x0F;  // Unregistered during negotiation
+
+  const auto &candidates = device_type_to_candidate_addresses(device_type_.value());
+
+  LockGuard send_lock(send_mutex_);
+
+  // First, try the spec-preferred addresses for our device type
+  for (uint8_t candidate : candidates) {
+    if (test_address_available_(candidate)) {
+      address_ = candidate;
+      ESP_LOGI(TAG, "Claimed logical address 0x%X", address_);
+      return;
+    }
+  }
+
+  // All preferred addresses taken. Fall back to any available address,
+  // starting from 0xE (reserved/rarely used) down through standard addresses.
+  // Skip 0xF (broadcast) and any we already tried above.
+  ESP_LOGI(TAG, "Preferred addresses taken, trying fallback addresses");
+  for (int8_t candidate = 0xE; candidate >= 0; candidate--) {
+    if (test_address_available_(candidate)) {
+      address_ = candidate;
+      ESP_LOGI(TAG, "Claimed fallback logical address 0x%X", address_);
+      return;
+    }
+  }
+
+  ESP_LOGW(TAG, "All addresses taken, using Unregistered (0xF)");
+}
+
+void HDMICEC::broadcast_physical_address_() {
+  auto physical_address_bytes = decode_value(physical_address_);
+  std::vector<uint8_t> data = {0x84};
+  data.insert(data.end(), physical_address_bytes.begin(), physical_address_bytes.end());
+  data.push_back(logical_address_to_device_type(address_));
+  send(address_, 0xF, data);
 }
 
 void HDMICEC::try_builtin_handler_(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data) {

--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -75,6 +75,10 @@ void HDMICEC::setup() {
     negotiate_address_();
     broadcast_physical_address_();
   }
+
+  if (scan_on_boot_ && !monitor_mode_) {
+    set_timeout("scan_boot", scan_boot_delay_ms_, [this]() { start_scan(); });
+  }
 }
 
 void HDMICEC::dump_config() {
@@ -111,6 +115,9 @@ void HDMICEC::loop() {
     // recycle received frame buffer
     frames_queue_.push_front();
 
+    // Always update device registry from known response opcodes
+    update_device_registry_(src_addr, dest_addr, data);
+
     // Process on_message triggers
     bool handled_by_trigger = false;
     uint8_t opcode = data[0];
@@ -133,6 +140,17 @@ void HDMICEC::loop() {
     bool is_directly_addressed = (dest_addr != 0xF && dest_addr == address_);
     if (is_directly_addressed && !handled_by_trigger) {
       try_builtin_handler_(src_addr, dest_addr, data);
+    }
+  }
+
+  // Send one initial probe per loop iteration during scan
+  if (scanning_) {
+    for (uint8_t i = 0; i <= MAX_LOGICAL_ADDRESS; i++) {
+      if (scan_pending_[i]) {
+        scan_pending_[i] = false;
+        send(address_, i, {0x83});  // Give Physical Address
+        break;
+      }
     }
   }
 }
@@ -261,6 +279,135 @@ void HDMICEC::broadcast_physical_address_() {
   send(address_, 0xF, data);
 }
 
+// --- Bus scanning ---
+
+void HDMICEC::start_scan() {
+  if (monitor_mode_) {
+    ESP_LOGW(TAG, "Cannot scan in monitor mode");
+    return;
+  }
+  cancel_timeout("scan_complete");
+  scanning_ = true;
+  last_scan_start_ms_ = millis();
+  for (uint8_t i = 0; i <= MAX_LOGICAL_ADDRESS; i++) {
+    scan_pending_[i] = (i != address_);
+  }
+  ESP_LOGI(TAG, "Starting CEC bus scan");
+  set_timeout("scan_complete", 10000, [this]() { complete_scan_(); });
+}
+
+void HDMICEC::complete_scan_() {
+  scanning_ = false;
+  ESP_LOGI(TAG, "CEC bus scan complete");
+  for (auto *trigger : scan_complete_triggers_) {
+    trigger->trigger();
+  }
+}
+
+void HDMICEC::update_device_registry_(uint8_t src, uint8_t dest, const std::vector<uint8_t> &data) {
+  if (data.empty() || src > MAX_LOGICAL_ADDRESS) return;
+
+  auto &dev = device_registry_[src];
+  dev.last_seen_ms = millis();
+
+  uint8_t opcode = data[0];
+  switch (opcode) {
+    case 0x84:  // Report Physical Address: [0x84, phys_hi, phys_lo, dev_type]
+      if (data.size() >= 4) {
+        dev.physical_address = (uint16_t(data[1]) << 8) | data[2];
+        dev.device_type = data[3];
+        ESP_LOGD(TAG, "Device 0x%X: physical_address=%04X device_type=%d", src, dev.physical_address, dev.device_type);
+      }
+      break;
+    case 0x47:  // Set OSD Name: [0x47, name_bytes...]
+      if (data.size() >= 2) {
+        dev.osd_name = std::string(data.begin() + 1, data.end());
+        ESP_LOGD(TAG, "Device 0x%X: osd_name='%s'", src, dev.osd_name.c_str());
+      }
+      break;
+    case 0x87:  // Device Vendor ID: [0x87, v1, v2, v3]
+      if (data.size() >= 4) {
+        dev.vendor_id = (uint32_t(data[1]) << 16) | (uint32_t(data[2]) << 8) | data[3];
+        ESP_LOGD(TAG, "Device 0x%X: vendor_id=%06X", src, dev.vendor_id);
+      }
+      break;
+    case 0x90:  // Report Power Status: [0x90, status]
+      if (data.size() >= 2) {
+        dev.power_status = data[1];
+        ESP_LOGD(TAG, "Device 0x%X: power_status=%d", src, dev.power_status);
+      }
+      break;
+    case 0x9E:  // CEC Version: [0x9E, version]
+      if (data.size() >= 2) {
+        dev.cec_version = data[1];
+        ESP_LOGD(TAG, "Device 0x%X: cec_version=%d", src, dev.cec_version);
+      }
+      break;
+    case 0x82:  // Active Source: [0x82, phys_hi, phys_lo] (broadcast)
+      if (data.size() >= 3) {
+        for (auto &d : device_registry_) d.active_source = false;
+        dev.active_source = true;
+        dev.physical_address = (uint16_t(data[1]) << 8) | data[2];
+        ESP_LOGD(TAG, "Device 0x%X: active_source, physical_address=%04X", src, dev.physical_address);
+      }
+      break;
+    default:
+      return;  // not a registry-relevant opcode
+  }
+
+  // During a scan, chain the next query based on the response we just got
+  if (scanning_) {
+    switch (opcode) {
+      case 0x84: send(address_, src, {0x8C}); break;  // → Give Device Vendor ID
+      case 0x87: send(address_, src, {0x46}); break;  // → Give OSD Name
+      case 0x47: send(address_, src, {0x8F}); break;  // → Give Device Power Status
+      case 0x90: send(address_, src, {0x9F}); break;  // → Get CEC Version
+      // 0x9E: last in chain, no follow-up
+      // 0x82: passive only, no chain
+    }
+  }
+}
+
+const DeviceInfo &HDMICEC::get_device_info(uint8_t logical_address) const {
+  static const DeviceInfo EMPTY{};
+  if (logical_address > MAX_LOGICAL_ADDRESS) return EMPTY;
+  return device_registry_[logical_address];
+}
+
+bool HDMICEC::seen_on_last_scan(uint8_t logical_address) const {
+  if (logical_address > MAX_LOGICAL_ADDRESS || last_scan_start_ms_ == 0) return false;
+  return device_registry_[logical_address].last_seen_ms >= last_scan_start_ms_;
+}
+
+optional<uint8_t> HDMICEC::find_address_by_osd_name(const std::string &name) const {
+  for (uint8_t i = 0; i <= MAX_LOGICAL_ADDRESS; i++) {
+    if (device_registry_[i].last_seen_ms > 0 && device_registry_[i].osd_name == name) {
+      return i;
+    }
+  }
+  return {};
+}
+
+optional<uint8_t> HDMICEC::find_address_by_physical_address(uint16_t addr) const {
+  for (uint8_t i = 0; i <= MAX_LOGICAL_ADDRESS; i++) {
+    if (device_registry_[i].last_seen_ms > 0 && device_registry_[i].physical_address == addr) {
+      return i;
+    }
+  }
+  return {};
+}
+
+optional<uint8_t> HDMICEC::find_address_by_vendor_and_type(uint32_t vendor_id, uint8_t device_type) const {
+  for (uint8_t i = 0; i <= MAX_LOGICAL_ADDRESS; i++) {
+    if (device_registry_[i].last_seen_ms > 0 &&
+        device_registry_[i].vendor_id == vendor_id &&
+        device_registry_[i].device_type == device_type) {
+      return i;
+    }
+  }
+  return {};
+}
+
 void HDMICEC::try_builtin_handler_(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data) {
   if (data.empty()) {
     return;
@@ -306,6 +453,13 @@ void HDMICEC::try_builtin_handler_(uint8_t source, uint8_t destination, const st
 
     // Ignore "Feature Abort" opcode responses
     case 0x00:
+    // Response opcodes handled by update_device_registry_ - don't Feature Abort them
+    case 0x82:  // Active Source
+    case 0x84:  // Report Physical Address
+    case 0x47:  // Set OSD Name
+    case 0x87:  // Device Vendor ID
+    case 0x90:  // Report Power Status
+    case 0x9E:  // CEC Version
       // no-op
       break;
 

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <string>
 #include <vector>
 #include <atomic>
 
@@ -85,7 +86,19 @@ class FrameRingBuffer {
   std::array<Frame*, SIZE + 1> store_;
 };
 
+struct DeviceInfo {
+  uint8_t device_type = 0xFF;
+  uint16_t physical_address = 0xFFFF;
+  std::string osd_name;
+  uint32_t vendor_id = 0xFFFFFF;
+  uint8_t power_status = 0xFF;
+  uint8_t cec_version = 0xFF;
+  bool active_source = false;
+  uint32_t last_seen_ms = 0;
+};
+
 class MessageTrigger;
+class ScanCompleteTrigger;
 
 class HDMICEC : public Component {
 public:
@@ -98,8 +111,22 @@ public:
   void set_osd_name_bytes(const std::vector<uint8_t> &osd_name_bytes) { osd_name_bytes_ = osd_name_bytes; }
   void set_device_type(uint8_t device_type) { device_type_ = device_type; negotiation_needed_ = true; }
   void add_message_trigger(MessageTrigger *trigger) { message_triggers_.push_back(trigger); }
+  void add_scan_complete_trigger(ScanCompleteTrigger *trigger) { scan_complete_triggers_.push_back(trigger); }
 
   bool send(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data_bytes);
+
+  // Bus scanning
+  void start_scan();
+  bool is_scanning() const { return scanning_; }
+  void set_scan_on_boot(bool val) { scan_on_boot_ = val; }
+  void set_scan_boot_delay(uint32_t ms) { scan_boot_delay_ms_ = ms; }
+
+  // Device registry queries
+  const DeviceInfo &get_device_info(uint8_t logical_address) const;
+  bool seen_on_last_scan(uint8_t logical_address) const;
+  optional<uint8_t> find_address_by_osd_name(const std::string &name) const;
+  optional<uint8_t> find_address_by_physical_address(uint16_t addr) const;
+  optional<uint8_t> find_address_by_vendor_and_type(uint32_t vendor_id, uint8_t device_type) const;
 
   // Component overrides
   float get_setup_priority() { return esphome::setup_priority::HARDWARE; }
@@ -114,6 +141,8 @@ protected:
   bool test_address_available_(uint8_t candidate_address);
   void negotiate_address_();
   void broadcast_physical_address_();
+  void complete_scan_();
+  void update_device_registry_(uint8_t src, uint8_t dest, const std::vector<uint8_t> &data);
   SendResult send_frame_(const Frame &frame, bool is_broadcast);
   bool send_start_bit_();
   void send_bit_(bool bit_value);
@@ -121,6 +150,7 @@ protected:
   void set_pin_input_high();
   void set_pin_output_low();
 
+  constexpr static uint8_t MAX_LOGICAL_ADDRESS = 0xE;  // highest assignable logical address (0xF is broadcast)
   constexpr static int MAX_FRAMES_QUEUED = 4;
   InternalGPIOPin *pin_;
   ISRInternalGPIOPin isr_pin_;
@@ -143,6 +173,15 @@ protected:
   FrameRingBuffer<MAX_FRAMES_QUEUED> frames_queue_;
   bool recv_ack_queued_ = false;
   Mutex send_mutex_;
+
+  // Device registry and scanning
+  std::array<DeviceInfo, MAX_LOGICAL_ADDRESS + 1> device_registry_;
+  bool scanning_ = false;
+  std::array<bool, MAX_LOGICAL_ADDRESS + 1> scan_pending_ = {};
+  uint32_t last_scan_start_ms_ = 0;
+  bool scan_on_boot_ = true;
+  uint32_t scan_boot_delay_ms_ = 3000;
+  std::vector<ScanCompleteTrigger*> scan_complete_triggers_;
 };
 
 class MessageTrigger : public Trigger<uint8_t, uint8_t, std::vector<uint8_t>> {
@@ -160,6 +199,19 @@ protected:
   optional<uint8_t> destination_;
   optional<uint8_t> opcode_;
   optional<std::vector<uint8_t>> data_;
+};
+
+class ScanCompleteTrigger : public Trigger<> {
+public:
+  explicit ScanCompleteTrigger(HDMICEC *parent) { parent->add_scan_complete_trigger(this); }
+};
+
+template<typename... Ts> class ScanBusAction : public Action<Ts...> {
+public:
+  ScanBusAction(HDMICEC *parent) : parent_(parent) {}
+  void play(const Ts&... x) override { parent_->start_scan(); }
+protected:
+  HDMICEC *parent_;
 };
 
 template<typename... Ts> class SendAction : public Action<Ts...> {

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -96,6 +96,7 @@ public:
   void set_promiscuous_mode(bool promiscuous_mode) { promiscuous_mode_ = promiscuous_mode; }
   void set_monitor_mode(bool monitor_mode) { monitor_mode_ = monitor_mode; }
   void set_osd_name_bytes(const std::vector<uint8_t> &osd_name_bytes) { osd_name_bytes_ = osd_name_bytes; }
+  void set_device_type(uint8_t device_type) { device_type_ = device_type; negotiation_needed_ = true; }
   void add_message_trigger(MessageTrigger *trigger) { message_triggers_.push_back(trigger); }
 
   bool send(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data_bytes);
@@ -110,6 +111,9 @@ protected:
   static void gpio_intr_(HDMICEC *self);
   static void reset_state_variables_(HDMICEC *self);
   void try_builtin_handler_(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data);
+  bool test_address_available_(uint8_t candidate_address);
+  void negotiate_address_();
+  void broadcast_physical_address_();
   SendResult send_frame_(const Frame &frame, bool is_broadcast);
   bool send_start_bit_();
   void send_bit_(bool bit_value);
@@ -124,6 +128,8 @@ protected:
   uint16_t physical_address_;
   bool promiscuous_mode_;
   bool monitor_mode_;
+  optional<uint8_t> device_type_;
+  bool negotiation_needed_ = false;
   std::vector<uint8_t> osd_name_bytes_;
   std::vector<MessageTrigger*> message_triggers_;
 

--- a/demo.yaml
+++ b/demo.yaml
@@ -45,7 +45,6 @@ captive_portal:
 
 hdmi_cec:
   pin: GPIO26
-  address: 0x5
   physical_address: 0x4000
   on_message:
     # Volume Up

--- a/demo.yaml
+++ b/demo.yaml
@@ -44,8 +44,22 @@ wifi:
 captive_portal:
 
 hdmi_cec:
+  id: cec
   pin: GPIO26
   physical_address: 0x4000
+  scan_on_boot: true
+  scan_boot_delay: 3s
+  on_scan_complete:
+    - then:
+        - lambda: |-
+            for (uint8_t i = 0; i < 15; i++) {
+              if (id(cec).seen_on_last_scan(i)) {
+                auto &dev = id(cec).get_device_info(i);
+                ESP_LOGI("cec_scan", "Device 0x%X: type=%d phys=%04X name='%s' vendor=%06X",
+                         i, dev.device_type, dev.physical_address,
+                         dev.osd_name.c_str(), dev.vendor_id);
+              }
+            }
   on_message:
     # Volume Up
     - data: [0x44, 0x41]


### PR DESCRIPTION
Two features I found myself needing:

- Automatic negotiation for logical address. The default address of 0x5 is pretty bad since that's going to conflict with any setup with a receiver or a soundbar. You can still use a manual address if you want but it's highly discouraged.

- Bus scanning - on boot, on demand, and passively. A client can look up a device by physical address, OSD name, or vendor id + device type. (My Panasonic Blu-ray player doesn't report an OSD, so I found this one really useful.)

Anyway, I needed these, wanted to share them upstream.