### PR TITLE
A whole bunch of updates!

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: Google
+AllowShortIfStatementsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: MultiLine
+ColumnLimit: 120
+PointerAlignment: Right
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 secrets.yaml
 .esphome/
 .vscode/
+.direnv/
+result
 
 # Created by https://www.toptal.com/developers/gitignore/api/python
 # Edit at https://www.toptal.com/developers/gitignore?templates=python

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Make your ESPHome devices speak the (machine) language of your living room with 
       - _"Give OSD Name"_
 - Send CEC commands
     - Built-in `hdmi_cec.send` action
+- Bus scanning & device discovery
+    - Automatic scan on startup with configurable delay
+    - On-demand scanning via `hdmi_cec.scan_bus` action
+    - Device registry with OSD name, physical address, vendor ID, power status, and more
+    - Query devices by logical address, OSD name, physical address, or vendor/type
+    - Passive registry updates from broadcast messages
 
 ### To-do list
 
@@ -108,6 +114,7 @@ The component automatically creates the following Home Assistant entities. No co
 | Entity | Type | Category | Description |
 | ------ | ---- | -------- | ----------- |
 | Logical Address | Text sensor | Diagnostic | The CEC logical address negotiated at startup (e.g. `0x4`) |
+| Scan CEC Bus | Button | Diagnostic | Triggers an on-demand scan of the CEC bus |
 
 **Customization example:**
 
@@ -117,6 +124,8 @@ hdmi_cec:
   logical_address:
     name: "CEC Address"
     icon: "mdi:hdmi-port"
+  scan_bus:
+    name: "Rescan CEC Devices"
 ```
 
 ---
@@ -187,7 +196,20 @@ api:
   custom_services: true
 ```
 
-This exposes the `esphome.<node>_send` service with `destination` (int) and `data` (int[]) parameters.
+This exposes the following services:
+
+| Service | Parameters | Description |
+|---------|-----------|-------------|
+| `esphome.<node>_send` | `destination` (int), `data` (int[]) | Send a raw CEC command |
+| `esphome.<node>_send_to_osd_name` | `osd_name` (string), `data` (int[]) | Send to a device by its OSD name |
+| `esphome.<node>_send_to_physical_address` | `physical_address` (int), `data` (int[]) | Send to a device by physical address |
+| `esphome.<node>_send_to_vendor_and_type` | `vendor_id` (int), `device_type` (int), `data` (int[]) | Send to a device by vendor ID and type |
+| `esphome.<node>_scan_bus` | _(none)_ | Trigger a CEC bus scan |
+
+Note that logical addresses are **subject to change** and so the send_to_* variants are more stable options, depending on your devices and needs:
+- OSD name is stable, if the device provides it, and as long as it isn't changed by device settings.
+- Phyiscal address is based on the phyiscal ports that your devices are plugged into. It is stable if and only if you leave devices you care about plugged into the same ports.
+- Vendor ID + Device Type is always stable, assuming you only have one matching device in your HDMI tree.
 
 **Example HA service call** (Developer Tools > Services):
 
@@ -285,6 +307,87 @@ hdmi_cec:
 
 ---
 
+### 6. Bus Scanning & Device Discovery
+
+The component can scan the CEC bus to discover connected devices and collect their information. Scanning is non-blocking and runs asynchronously in the background.
+
+#### Configuration
+
+```yaml
+hdmi_cec:
+  id: cec
+  pin: GPIO26
+  physical_address: 0x4000
+  device_type: playback_device
+
+  # Scan the bus on startup (default: true)
+  scan_on_boot: true
+
+  # Delay before the initial scan, to let other devices finish negotiation (default: 3s)
+  scan_boot_delay: 3s
+
+  # Trigger when a scan completes
+  on_scan_complete:
+    - then:
+        - logger.log: "CEC bus scan complete"
+```
+
+Scan results are logged at INFO level. To expose device state as entities in Home Assistant, see "User-Defined CEC Devices" below.
+
+#### Triggering a scan manually
+
+Use the `hdmi_cec.scan_bus` action from any automation:
+
+```yaml
+button:
+  - platform: template
+    name: "Scan CEC Bus"
+    on_press:
+      - hdmi_cec.scan_bus
+```
+
+#### Querying the device registry from lambdas
+
+The scan populates a per-device registry (logical addresses 0-14) with the following fields:
+
+| Field | Type | Default (unknown) | Source |
+|-------|------|--------------------|--------|
+| `device_type` | `uint8_t` | `0xFF` | Report Physical Address |
+| `physical_address` | `uint16_t` | `0xFFFF` | Report Physical Address |
+| `osd_name` | `std::string` | `""` | Set OSD Name |
+| `vendor_id` | `uint32_t` | `0xFFFFFF` | Device Vendor ID |
+| `power_status` | `uint8_t` | `0xFF` | Report Power Status |
+| `cec_version` | `uint8_t` | `0xFF` | CEC Version |
+| `active_source` | `bool` | `false` | Active Source broadcast |
+| `last_seen_ms` | `uint32_t` | `0` | Any response from device |
+
+Available query methods:
+
+```cpp
+// Get info for a specific logical address
+auto &dev = id(cec).get_device(0);  // TV is usually address 0
+
+// Check if a device was seen on the most recent scan
+bool tv_present = id(cec).seen_on_last_scan(0);
+
+// Find a device by OSD name
+auto addr = id(cec).find_address_by_osd_name("Samsung TV");
+if (addr.has_value()) { /* use *addr */ }
+
+// Find a device by physical address
+auto addr = id(cec).find_address_by_physical_address(0x1000);
+
+// Find a device by vendor ID and device type (useful for devices without OSD names)
+auto addr = id(cec).find_address_by_vendor_and_type(0x000678, 0x04);  // e.g., Panasonic playback device
+
+// Check if a scan is currently running
+bool scanning = id(cec).is_scanning();
+```
+
+The registry is also updated passively from broadcast messages (Report Physical Address, Device Vendor ID, Active Source) even outside of active scans.
+
+---
+
 ## Advanced Example (All Features Combined)
 
 Here’s a full YAML snippet that includes all optional features together (just delete what you don't need):
@@ -306,7 +409,7 @@ logger:
 api:
   encryption:
     key: "..."
-  # Enable CEC services (send, etc.) in Home Assistant
+  # Enable CEC services (send, scan_bus, etc.) in Home Assistant
   custom_services: true
 
 ota:

--- a/README.md
+++ b/README.md
@@ -388,6 +388,115 @@ The registry is also updated passively from broadcast messages (Report Physical 
 
 ---
 
+### 7. User-Defined CEC Devices
+
+Define specific CEC devices you want to interact with under `devices:`. Each device becomes an ESPHome sub-device with its own entity group in Home Assistant. Only the entities you configure are created, keeping memory usage low.
+
+All entity keys below are optional. A bare key (e.g. `power_switch:`) creates the entity with a default name of `"{device name} {label}"` — Home Assistant strips the device name prefix when displaying under the sub-device card, so `"Blu-ray Player Power"` shows as **Power**.
+
+#### Example
+
+```yaml
+hdmi_cec:
+  id: cec
+  pin: GPIO26
+  physical_address: 0x4000
+  scan_on_boot: true
+
+  devices:
+    - id: bluray
+      name: "Blu-ray Player"
+      match:
+        osd_name: "BD Player"
+        vendor_id: 0x080046
+      power_switch:
+        name: "BD Power"
+        icon: "mdi:disc-player"
+      power_status_sensor:
+        name: "BD Status"
+        icon: "mdi:power-settings"
+      active_source_sensor:
+      navigation_buttons:
+      transport_buttons:
+
+    - id: soundbar
+      name: "Soundbar"
+      match:
+        vendor_id: 0x0000F0
+        device_type: audio_system
+      power_switch:
+      volume_buttons:
+```
+
+#### Device matching
+
+Each device requires a `match:` block with at least one criterion. All criteria are AND-combined. After a bus scan (or from ongoing CEC traffic), the component resolves each device to its current logical address.
+
+| Key | Type | Description | Stability | Uniqueness |
+|-----|------|-------------|-----------|------------|
+| `osd_name` | string | Match by the device's on-screen display name | As long as it's not changed in device settings (if applicable.) Not reported by all devices. | Maybe? |
+| `vendor_id` | int | Match by 24-bit vendor ID (e.g. `0x080046`) | Never changes | Depends on your devices |
+| `device_type` | enum | Match by device type: `tv`, `recording_device`, `tuner`, `playback_device`, `audio_system`, `other` | Never changes | Depends on your devices |
+| `physical_address` | int | Match by 16-bit HDMI topology address (e.g. `0x2000`) | Changes if/when you move it to a different plug | Always unquie |
+
+#### Power switch
+
+Sends Image View On (power on) or Standby (power off). Use a bare key for defaults, or customize with any options from [Switch](https://esphome.io/components/switch/).
+
+#### Sensors
+
+Each sensor key can be a bare key or customized with standard options.
+
+| Key | Type | Default label | Description |
+|-----|------|---------------|-------------|
+| `osd_name_sensor` | Text | OSD Name | Device's on-screen display name |
+| `device_type_sensor` | Text | Device Type | TV, Playback Device, Audio System, etc. |
+| `vendor_id_sensor` | Text | Vendor ID | Hex string (e.g. "0x080046") |
+| `vendor_name_sensor` | Text | Vendor Name | Manufacturer (e.g. "Sony") |
+| `physical_address_sensor` | Text | Physical Address | HDMI topology address (e.g. "2.0.0.0") |
+| `power_status_sensor` | Text | Power Status | On / Standby / Transitioning |
+| `cec_version_sensor` | Text | CEC Version | Protocol version string |
+| `active_source_sensor` | Binary | Active Source | Whether this device is the active HDMI source |
+| `last_seen_sensor` | Text | Last Seen | Time since last bus activity |
+
+All other options from [Text Sensor](https://esphome.io/components/text_sensor/) or [Binary Sensor](https://esphome.io/components/binary_sensor/) depending on the type above.
+
+#### Button groups
+
+Each key creates a group of [Button](https://esphome.io/components/button/) entities that send CEC User Control Pressed + Released commands to the device. These are bare keys only — they take no sub-options. Individual button names and icons are auto-generated.
+
+| Key | Buttons created |
+|-----|-----------------|
+| `navigation_buttons` | Select, Up, Down, Left, Right, Root Menu, Back |
+| `transport_buttons` | Play, Stop, Pause, Record, Rewind, Fast Forward, Play/Pause |
+| `volume_buttons` | Volume Up, Volume Down, Mute |
+| `power_buttons` | Power Toggle, Power Off, Power On |
+| `number_buttons` | 0–9, Dot, Enter, Clear, Number Entry Mode, 11, 12 |
+| `channel_buttons` | Channel Up, Channel Down, Previous Channel |
+| `color_buttons` | Blue, Red, Green, Yellow |
+
+#### Sending to a device by ID
+
+Use the `hdmi_cec.send_to_device` action to send raw CEC data to a user-defined device. The device's logical address is resolved automatically from the match criteria.
+
+```yaml
+on_...:
+  then:
+    - hdmi_cec.send_to_device:
+        device: bluray
+        data: [0x44, 0x00]  # User Control Pressed: Select
+```
+
+Each device also gets an automatic Home Assistant service: `esphome.<node>_send_to_device_<id>` with a single `data` (int[]) parameter. For example, with `id: bluray`:
+
+```yaml
+service: esphome.hdmi_cec_bridge_send_to_device_bluray
+data:
+  data: [0x44, 0x00]  # User Control Pressed: Select
+```
+
+---
+
 ## Advanced Example (All Features Combined)
 
 Here’s a full YAML snippet that includes all optional features together (just delete what you don't need):

--- a/README.md
+++ b/README.md
@@ -150,24 +150,24 @@ button:
 
 ---
 
-### 3. Enable CEC Commands via Home Assistant Services
+### 3. Home Assistant Services
 
-Under `api:`:
+Enable `custom_services: true` in your `api:` config to automatically register CEC services in Home Assistant:
 
 ```yaml
 api:
-  services:
-    - service: hdmi_cec_send
-      variables:
-        cec_destination: int
-        cec_data: int[]
-      then:
-        - hdmi_cec.send:
-            destination: !lambda "return static_cast<unsigned char>(cec_destination);"
-            data: !lambda |-
-              std::vector<unsigned char> vec;
-              for (int i : cec_data) vec.push_back(static_cast<unsigned char>(i));
-              return vec;
+  custom_services: true
+```
+
+This exposes the `esphome.<node>_send` service with `destination` (int) and `data` (int[]) parameters.
+
+**Example HA service call** (Developer Tools > Services):
+
+```yaml
+service: esphome.hdmi_cec_bridge_send
+data:
+  destination: 0
+  data: [0x04]  # Image View On (turn TV on)
 ```
 
 ---
@@ -278,16 +278,8 @@ logger:
 api:
   encryption:
     key: "..."
-  
-  services:
-    - service: hdmi_cec_send
-      variables:
-        cec_destination: int
-        cec_data: int[]
-      then:
-        - hdmi_cec.send:
-            destination: !lambda "return static_cast<unsigned char>(cec_destination);"
-            data: !lambda "std::vector<unsigned char> charVector; for (int i : cec_data) { charVector.push_back(static_cast<unsigned char>(i)); } return charVector;"
+  # Enable CEC services (send, etc.) in Home Assistant
+  custom_services: true
 
 ota:
   - platform: esphome

--- a/README.md
+++ b/README.md
@@ -67,22 +67,22 @@ Add the `hdmi_cec:` block:
 hdmi_cec:
   # Pick a GPIO pin that can do both input AND output
   pin: GPIO26 # Required
-  
-  # The address can be anything you want. Use 0xF if you only want to listen to the bus and not act like a standard device
-  address: 0xE # Required
-  
+
+  # The type of CEC device to present as. Used for automatic logical address negotiation.
+  # Options: tv, recording_device, tuner, playback_device, audio_system, other
+  # device_type: playback_device # Optional. Defaults to "other"
+
   # Physical address of the device. In this case: 4.0.0.0 (HDMI4 on the TV)
   # DDC support is not yet implemented, so you'll have to set this manually.
   physical_address: 0x4000 # Required
-  
+
   # The name that will be displayed in the list of devices on your TV/receiver
   osd_name: "my device" # Optional. Defaults to "esphome"
-  
-  # By default, promiscuous mode is disabled, so the component only handles directly-address messages (matching
-  # the address configured above) and broadcast messages. Enabling promiscuous mode will make the component
+
+  # By default, promiscuous mode is disabled, so the component only handles directly-addressed messages and broadcast messages. Enabling promiscuous mode will make the component
   # listen for all messages (both in logs and the on_message triggers)
   promiscuous_mode: false # Optional. Defaults to false
-  
+
   # By default, monitor mode is disabled, so the component can send messages and acknowledge incoming messages.
   # Enabling monitor mode lets the component act as a passive listener, disabling active manipulation of the CEC bus.
   monitor_mode: false # Optional. Defaults to false
@@ -90,6 +90,34 @@ hdmi_cec:
 ```
 
 You now have a functioning CEC receiver.
+
+> **Note on `address` (backward-compatibility only):** The `address` option still exists for backward
+> compatibility, allowing you to hard-code a logical address (e.g., `address: 0xE`). However, this is
+> **strongly discouraged** because it bypasses the CEC bus negotiation protocol: if another device on
+> the bus already uses the same address, both devices will malfunction (garbled commands, missed
+> messages, or devices disappearing from the TV's device list). Using `device_type` lets the component
+> negotiate a free address automatically at startup, which is the correct behavior per the HDMI-CEC
+> specification. A compile-time warning is emitted when `address` is used.
+
+---
+
+## Entities
+
+The component automatically creates the following Home Assistant entities. No configuration is needed — they appear as soon as the component is loaded. Each can be customized under the `hdmi_cec:` block (e.g. to change the name or icon).
+
+| Entity | Type | Category | Description |
+| ------ | ---- | -------- | ----------- |
+| Logical Address | Text sensor | Diagnostic | The CEC logical address negotiated at startup (e.g. `0x4`) |
+
+**Customization example:**
+
+```yaml
+hdmi_cec:
+  ...
+  logical_address:
+    name: "CEC Address"
+    icon: "mdi:hdmi-port"
+```
 
 ---
 
@@ -308,22 +336,22 @@ external_components:
 hdmi_cec:
   # Pick a GPIO pin that can do both input AND output
   pin: GPIO10 # Required
-  
-  # The address can be anything you want. Use 0xF if you only want to listen to the bus and not act like a standard device
-  address: 0xE # Required
-  
+
+  # The type of CEC device to present as. Used for automatic logical address negotiation.
+  # Options: tv, recording_device, tuner, playback_device, audio_system, other
+  device_type: playback_device # Optional. Defaults to "other"
+
   # Physical address of the device. In this case: 4.2.0.0 (The ESP32 is plugged into HDMI 2 on the receiver which is plugged into HDMI4 on the TV)
   # DDC support is not yet implemented, so you'll have to set this manually.
   physical_address: 0x4200 # Required
-  
+
   # The name that will be displayed in the list of devices on your TV/receiver
   osd_name: "HDMI Bridge" # Optional. Defaults to "esphome"
-  
-  # By default, promiscuous mode is disabled, so the component only handles directly addressed messages (matching
-  # the address configured above) and broadcast messages. Enabling promiscuous mode will make the component
+
+  # By default, promiscuous mode is disabled, so the component only handles directly-addressed messages and broadcast messages. Enabling promiscuous mode will make the component
   # listen for all messages (both in logs and the on_message triggers)
   promiscuous_mode: true # Optional. Defaults to false
-  
+
   # By default, monitor mode is disabled, so the component can send messages and acknowledge incoming messages.
   # Enabling monitor mode lets the component act as a passive listener, disabling active manipulation of the CEC bus.
   monitor_mode: false # Optional. Defaults to false

--- a/components/hdmi_cec/__init__.py
+++ b/components/hdmi_cec/__init__.py
@@ -1,10 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins, automation
-from esphome.const import (
-    CONF_ID,
-    CONF_TRIGGER_ID
-)
+from esphome.const import CONF_ID, CONF_TRIGGER_ID
 
 CODEOWNERS = ["@Palakis"]
 
@@ -23,10 +20,12 @@ CONF_OPCODE = "opcode"
 CONF_DATA = "data"
 CONF_PARENT = "parent"
 
+
 def validate_data_array(value):
     if isinstance(value, list):
         return cv.Schema([cv.hex_uint8_t])(value)
     raise cv.Invalid("data must be a list of bytes")
+
 
 def validate_osd_name(value):
     if not isinstance(value, str):
@@ -35,7 +34,7 @@ def validate_osd_name(value):
         raise cv.Invalid("Must be a non-empty string")
     if len(value) > 14:
         raise cv.Invalid("Must not be more than 14-characters long")
-    
+
     for char in value:
         if not 0x20 <= ord(char) < 0x7E:
             raise cv.Invalid(
@@ -44,16 +43,13 @@ def validate_osd_name(value):
 
     return value
 
+
 hdmi_cec_ns = cg.esphome_ns.namespace("hdmi_cec")
-HDMICEC = hdmi_cec_ns.class_(
-    "HDMICEC", cg.Component
-)
+HDMICEC = hdmi_cec_ns.class_("HDMICEC", cg.Component)
 MessageTrigger = hdmi_cec_ns.class_(
     "MessageTrigger", automation.Trigger.template(cg.uint8, cg.uint8, cg.std_vector.template(cg.uint8))
 )
-SendAction = hdmi_cec_ns.class_(
-    "SendAction", automation.Action
-)
+SendAction = hdmi_cec_ns.class_("SendAction", automation.Action)
 
 CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend(
     {
@@ -71,15 +67,16 @@ CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend(
                 cv.Optional(CONF_SOURCE): cv.int_range(min=0, max=15),
                 cv.Optional(CONF_DESTINATION): cv.int_range(min=0, max=15),
                 cv.Optional(CONF_OPCODE): cv.uint8_t,
-                cv.Optional(CONF_DATA): validate_data_array
+                cv.Optional(CONF_DATA): validate_data_array,
             }
-        )
+        ),
     }
 )
 
+
 async def to_code(config):
     if config[CONF_DECODE_MESSAGES] == True:
-        cg.add_define('USE_CEC_DECODER')
+        cg.add_define("USE_CEC_DECODER")
 
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
@@ -92,8 +89,8 @@ async def to_code(config):
     cg.add(var.set_promiscuous_mode(config[CONF_PROMISCUOUS_MODE]))
     cg.add(var.set_monitor_mode(config[CONF_MONITOR_MODE]))
 
-    osd_name_bytes = bytes(config[CONF_OSD_NAME], 'ascii', 'ignore') # convert string to ascii bytes
-    osd_name_bytes = [x for x in osd_name_bytes] # convert byte array to int array
+    osd_name_bytes = bytes(config[CONF_OSD_NAME], "ascii", "ignore")  # convert string to ascii bytes
+    osd_name_bytes = [x for x in osd_name_bytes]  # convert byte array to int array
     osd_name_bytes = cg.std_vector.template(cg.uint8)(osd_name_bytes)
     cg.add(var.set_osd_name_bytes(osd_name_bytes))
 
@@ -117,14 +114,9 @@ async def to_code(config):
             cg.add(trigger.set_data(data))
 
         await automation.build_automation(
-            trigger,
-            [
-                (cg.uint8, "source"),
-                (cg.uint8, "destination"),
-                (cg.std_vector.template(cg.uint8), "data")
-            ],
-            conf
+            trigger, [(cg.uint8, "source"), (cg.uint8, "destination"), (cg.std_vector.template(cg.uint8), "data")], conf
         )
+
 
 @automation.register_action(
     "hdmi_cec.send",
@@ -133,8 +125,8 @@ async def to_code(config):
         cv.GenerateID(CONF_PARENT): cv.use_id(HDMICEC),
         cv.Optional(CONF_SOURCE): cv.templatable(cv.int_range(min=0, max=15)),
         cv.Required(CONF_DESTINATION): cv.templatable(cv.int_range(min=0, max=15)),
-        cv.Required(CONF_DATA): cv.templatable(validate_data_array)
-    }
+        cv.Required(CONF_DATA): cv.templatable(validate_data_array),
+    },
 )
 async def send_action_to_code(config, action_id, template_args, args):
     parent = await cg.get_variable(config[CONF_PARENT])

--- a/components/hdmi_cec/__init__.py
+++ b/components/hdmi_cec/__init__.py
@@ -1,9 +1,15 @@
+import logging
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins, automation
-from esphome.const import CONF_ID, CONF_TRIGGER_ID
+from esphome.components import text_sensor
+from esphome.const import CONF_ID, CONF_TRIGGER_ID, ENTITY_CATEGORY_DIAGNOSTIC
+
+_LOGGER = logging.getLogger(__name__)
 
 CODEOWNERS = ["@Palakis"]
+AUTO_LOAD = ["text_sensor"]
 
 CONF_PIN = "pin"
 CONF_ADDRESS = "address"
@@ -13,12 +19,23 @@ CONF_MONITOR_MODE = "monitor_mode"
 CONF_DECODE_MESSAGES = "decode_messages"
 CONF_OSD_NAME = "osd_name"
 CONF_ON_MESSAGE = "on_message"
+CONF_DEVICE_TYPE = "device_type"
 
+CONF_LOGICAL_ADDRESS = "logical_address"
 CONF_SOURCE = "source"
 CONF_DESTINATION = "destination"
 CONF_OPCODE = "opcode"
 CONF_DATA = "data"
 CONF_PARENT = "parent"
+
+DEVICE_TYPES = {
+    "tv": 0x00,
+    "recording_device": 0x01,
+    "tuner": 0x03,
+    "playback_device": 0x04,
+    "audio_system": 0x05,
+    "other": 0xFF,
+}
 
 
 def validate_data_array(value):
@@ -47,30 +64,47 @@ def validate_osd_name(value):
 hdmi_cec_ns = cg.esphome_ns.namespace("hdmi_cec")
 HDMICEC = hdmi_cec_ns.class_("HDMICEC", cg.Component)
 MessageTrigger = hdmi_cec_ns.class_(
-    "MessageTrigger", automation.Trigger.template(cg.uint8, cg.uint8, cg.std_vector.template(cg.uint8))
+    "MessageTrigger",
+    automation.Trigger.template(cg.uint8, cg.uint8, cg.std_vector.template(cg.uint8)),
 )
 SendAction = hdmi_cec_ns.class_("SendAction", automation.Action)
 
-CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(HDMICEC),
-        cv.Required(CONF_PIN): pins.internal_gpio_output_pin_schema,
-        cv.Required(CONF_ADDRESS): cv.int_range(min=0, max=15),
-        cv.Required(CONF_PHYSICAL_ADDRESS): cv.uint16_t,
-        cv.Optional(CONF_PROMISCUOUS_MODE, False): cv.boolean,
-        cv.Optional(CONF_MONITOR_MODE, False): cv.boolean,
-        cv.Optional(CONF_DECODE_MESSAGES, True): cv.boolean,
-        cv.Optional(CONF_OSD_NAME, "esphome"): validate_osd_name,
-        cv.Optional(CONF_ON_MESSAGE): automation.validate_automation(
-            {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MessageTrigger),
-                cv.Optional(CONF_SOURCE): cv.int_range(min=0, max=15),
-                cv.Optional(CONF_DESTINATION): cv.int_range(min=0, max=15),
-                cv.Optional(CONF_OPCODE): cv.uint8_t,
-                cv.Optional(CONF_DATA): validate_data_array,
-            }
-        ),
-    }
+
+def validate_address_config(config):
+    has_device_type = CONF_DEVICE_TYPE in config or CONF_ADDRESS not in config
+    if has_device_type and config.get(CONF_MONITOR_MODE, False):
+        raise cv.Invalid("'device_type' cannot be used with 'monitor_mode' (passive devices don't negotiate)")
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.COMPONENT_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(HDMICEC),
+            cv.Required(CONF_PIN): pins.internal_gpio_output_pin_schema,
+            cv.Optional(CONF_ADDRESS): cv.int_range(min=0, max=15),
+            cv.Required(CONF_PHYSICAL_ADDRESS): cv.uint16_t,
+            cv.Optional(CONF_DEVICE_TYPE): cv.enum(DEVICE_TYPES, lower=True),
+            cv.Optional(CONF_PROMISCUOUS_MODE, False): cv.boolean,
+            cv.Optional(CONF_MONITOR_MODE, False): cv.boolean,
+            cv.Optional(CONF_DECODE_MESSAGES, True): cv.boolean,
+            cv.Optional(CONF_OSD_NAME, "esphome"): validate_osd_name,
+            cv.Optional(CONF_LOGICAL_ADDRESS, default={"name": "Logical Address"}): text_sensor.text_sensor_schema(
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                icon="mdi:mail",
+            ),
+            cv.Optional(CONF_ON_MESSAGE): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MessageTrigger),
+                    cv.Optional(CONF_SOURCE): cv.int_range(min=0, max=15),
+                    cv.Optional(CONF_DESTINATION): cv.int_range(min=0, max=15),
+                    cv.Optional(CONF_OPCODE): cv.uint8_t,
+                    cv.Optional(CONF_DATA): validate_data_array,
+                }
+            ),
+        }
+    ),
+    validate_address_config,
 )
 
 
@@ -81,10 +115,24 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 
+    if CONF_LOGICAL_ADDRESS in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_LOGICAL_ADDRESS])
+        cg.add(var.set_address_sensor(sens))
+
     cec_pin_ = await cg.gpio_pin_expression(config[CONF_PIN])
     cg.add(var.set_pin(cec_pin_))
 
-    cg.add(var.set_address(config[CONF_ADDRESS]))
+    if CONF_ADDRESS in config:
+        _LOGGER.warning(
+            "hdmi_cec: Manually setting 'address' bypasses logical address auto-negotiation and is deprecated. This can cause conflicts with other CEC devices on the bus. Remove 'address' to allow auto-negotiation."
+        )
+        cg.add(var.set_address(config[CONF_ADDRESS]))
+    else:
+        cg.add(var.set_address(0x0F))  # Unregistered until negotiation
+
+    if CONF_ADDRESS not in config:
+        cg.add(var.set_device_type(config.get(CONF_DEVICE_TYPE, DEVICE_TYPES["other"])))
+
     cg.add(var.set_physical_address(config[CONF_PHYSICAL_ADDRESS]))
     cg.add(var.set_promiscuous_mode(config[CONF_PROMISCUOUS_MODE]))
     cg.add(var.set_monitor_mode(config[CONF_MONITOR_MODE]))
@@ -114,7 +162,13 @@ async def to_code(config):
             cg.add(trigger.set_data(data))
 
         await automation.build_automation(
-            trigger, [(cg.uint8, "source"), (cg.uint8, "destination"), (cg.std_vector.template(cg.uint8), "data")], conf
+            trigger,
+            [
+                (cg.uint8, "source"),
+                (cg.uint8, "destination"),
+                (cg.std_vector.template(cg.uint8), "data"),
+            ],
+            conf,
         )
 
 

--- a/components/hdmi_cec/__init__.py
+++ b/components/hdmi_cec/__init__.py
@@ -4,12 +4,13 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins, automation
 from esphome.components import text_sensor
+from esphome.components import button as button_platform
 from esphome.const import CONF_ID, CONF_TRIGGER_ID, ENTITY_CATEGORY_DIAGNOSTIC
 
 _LOGGER = logging.getLogger(__name__)
 
 CODEOWNERS = ["@Palakis"]
-AUTO_LOAD = ["text_sensor"]
+AUTO_LOAD = ["text_sensor", "button"]
 
 CONF_PIN = "pin"
 CONF_ADDRESS = "address"
@@ -22,11 +23,18 @@ CONF_ON_MESSAGE = "on_message"
 CONF_DEVICE_TYPE = "device_type"
 
 CONF_LOGICAL_ADDRESS = "logical_address"
+CONF_ACTIVE_SOURCE = "active_source"
+CONF_SCAN_BUS_BUTTON = "scan_bus"
 CONF_SOURCE = "source"
 CONF_DESTINATION = "destination"
 CONF_OPCODE = "opcode"
 CONF_DATA = "data"
 CONF_PARENT = "parent"
+CONF_OSD_NAME_TARGET = "osd_name"
+CONF_VENDOR_ID = "vendor_id"
+CONF_SCAN_ON_BOOT = "scan_on_boot"
+CONF_SCAN_BOOT_DELAY = "scan_boot_delay"
+CONF_ON_SCAN_COMPLETE = "on_scan_complete"
 
 DEVICE_TYPES = {
     "tv": 0x00,
@@ -68,6 +76,12 @@ MessageTrigger = hdmi_cec_ns.class_(
     automation.Trigger.template(cg.uint8, cg.uint8, cg.std_vector.template(cg.uint8)),
 )
 SendAction = hdmi_cec_ns.class_("SendAction", automation.Action)
+SendToOsdNameAction = hdmi_cec_ns.class_("SendToOsdNameAction", automation.Action)
+SendToPhysicalAddressAction = hdmi_cec_ns.class_("SendToPhysicalAddressAction", automation.Action)
+SendToVendorAndTypeAction = hdmi_cec_ns.class_("SendToVendorAndTypeAction", automation.Action)
+ScanBusAction = hdmi_cec_ns.class_("ScanBusAction", automation.Action)
+ScanCompleteTrigger = hdmi_cec_ns.class_("ScanCompleteTrigger", automation.Trigger.template())
+ScanButton = hdmi_cec_ns.class_("ScanButton", button_platform.Button)
 
 
 def validate_address_config(config):
@@ -92,6 +106,21 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_LOGICAL_ADDRESS, default={"name": "Logical Address"}): text_sensor.text_sensor_schema(
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                 icon="mdi:mail",
+            ),
+            cv.Optional(CONF_ACTIVE_SOURCE, default={"name": "Active Source"}): text_sensor.text_sensor_schema(
+                icon="mdi:video-input-hdmi",
+            ),
+            cv.Optional(CONF_SCAN_BUS_BUTTON, default={"name": "Scan CEC Bus"}): button_platform.button_schema(
+                ScanButton,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                icon="mdi:magnify",
+            ),
+            cv.Optional(CONF_SCAN_ON_BOOT, default=True): cv.boolean,
+            cv.Optional(CONF_SCAN_BOOT_DELAY, default="3s"): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_ON_SCAN_COMPLETE): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ScanCompleteTrigger),
+                }
             ),
             cv.Optional(CONF_ON_MESSAGE): automation.validate_automation(
                 {
@@ -119,6 +148,14 @@ async def to_code(config):
         sens = await text_sensor.new_text_sensor(config[CONF_LOGICAL_ADDRESS])
         cg.add(var.set_address_sensor(sens))
 
+    if CONF_ACTIVE_SOURCE in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_ACTIVE_SOURCE])
+        cg.add(var.set_active_source_sensor(sens))
+
+    if CONF_SCAN_BUS_BUTTON in config:
+        btn = await button_platform.new_button(config[CONF_SCAN_BUS_BUTTON])
+        cg.add(btn.set_parent(var))
+
     cec_pin_ = await cg.gpio_pin_expression(config[CONF_PIN])
     cg.add(var.set_pin(cec_pin_))
 
@@ -141,6 +178,13 @@ async def to_code(config):
     osd_name_bytes = [x for x in osd_name_bytes]  # convert byte array to int array
     osd_name_bytes = cg.std_vector.template(cg.uint8)(osd_name_bytes)
     cg.add(var.set_osd_name_bytes(osd_name_bytes))
+
+    cg.add(var.set_scan_on_boot(config[CONF_SCAN_ON_BOOT]))
+    cg.add(var.set_scan_boot_delay(config[CONF_SCAN_BOOT_DELAY]))
+
+    for conf in config.get(CONF_ON_SCAN_COMPLETE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
 
     for conf in config.get(CONF_ON_MESSAGE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
@@ -195,6 +239,106 @@ async def send_action_to_code(config, action_id, template_args, args):
 
     data_vec_ = cg.std_vector.template(cg.uint8)
     data_template_ = await cg.templatable(config.get(CONF_DATA), args, data_vec_, data_vec_)
+    cg.add(var.set_data(data_template_))
+
+    return var
+
+
+@automation.register_action(
+    "hdmi_cec.scan_bus",
+    ScanBusAction,
+    {
+        cv.GenerateID(CONF_PARENT): cv.use_id(HDMICEC),
+    },
+)
+async def scan_bus_action_to_code(config, action_id, template_args, args):
+    parent = await cg.get_variable(config[CONF_PARENT])
+    return cg.new_Pvariable(action_id, template_args, parent)
+
+
+@automation.register_action(
+    "hdmi_cec.send_to_osd_name",
+    SendToOsdNameAction,
+    {
+        cv.GenerateID(CONF_PARENT): cv.use_id(HDMICEC),
+        cv.Optional(CONF_SOURCE): cv.templatable(cv.int_range(min=0, max=15)),
+        cv.Required(CONF_OSD_NAME_TARGET): cv.templatable(cv.string),
+        cv.Required(CONF_DATA): cv.templatable(validate_data_array),
+    },
+)
+async def send_to_osd_name_action_to_code(config, action_id, template_args, args):
+    parent = await cg.get_variable(config[CONF_PARENT])
+    var = cg.new_Pvariable(action_id, template_args, parent)
+
+    source_template_ = await cg.templatable(config.get(CONF_SOURCE), args, cg.uint8)
+    if source_template_ is not None:
+        cg.add(var.set_source(source_template_))
+
+    osd_name_template_ = await cg.templatable(config[CONF_OSD_NAME_TARGET], args, cg.std_string)
+    cg.add(var.set_osd_name(osd_name_template_))
+
+    data_vec_ = cg.std_vector.template(cg.uint8)
+    data_template_ = await cg.templatable(config[CONF_DATA], args, data_vec_, data_vec_)
+    cg.add(var.set_data(data_template_))
+
+    return var
+
+
+@automation.register_action(
+    "hdmi_cec.send_to_physical_address",
+    SendToPhysicalAddressAction,
+    {
+        cv.GenerateID(CONF_PARENT): cv.use_id(HDMICEC),
+        cv.Optional(CONF_SOURCE): cv.templatable(cv.int_range(min=0, max=15)),
+        cv.Required(CONF_PHYSICAL_ADDRESS): cv.templatable(cv.uint16_t),
+        cv.Required(CONF_DATA): cv.templatable(validate_data_array),
+    },
+)
+async def send_to_physical_address_action_to_code(config, action_id, template_args, args):
+    parent = await cg.get_variable(config[CONF_PARENT])
+    var = cg.new_Pvariable(action_id, template_args, parent)
+
+    source_template_ = await cg.templatable(config.get(CONF_SOURCE), args, cg.uint8)
+    if source_template_ is not None:
+        cg.add(var.set_source(source_template_))
+
+    phys_template_ = await cg.templatable(config[CONF_PHYSICAL_ADDRESS], args, cg.uint16)
+    cg.add(var.set_physical_address(phys_template_))
+
+    data_vec_ = cg.std_vector.template(cg.uint8)
+    data_template_ = await cg.templatable(config[CONF_DATA], args, data_vec_, data_vec_)
+    cg.add(var.set_data(data_template_))
+
+    return var
+
+
+@automation.register_action(
+    "hdmi_cec.send_to_vendor_and_type",
+    SendToVendorAndTypeAction,
+    {
+        cv.GenerateID(CONF_PARENT): cv.use_id(HDMICEC),
+        cv.Optional(CONF_SOURCE): cv.templatable(cv.int_range(min=0, max=15)),
+        cv.Required(CONF_VENDOR_ID): cv.templatable(cv.uint32_t),
+        cv.Required(CONF_DEVICE_TYPE): cv.templatable(cv.uint8_t),
+        cv.Required(CONF_DATA): cv.templatable(validate_data_array),
+    },
+)
+async def send_to_vendor_and_type_action_to_code(config, action_id, template_args, args):
+    parent = await cg.get_variable(config[CONF_PARENT])
+    var = cg.new_Pvariable(action_id, template_args, parent)
+
+    source_template_ = await cg.templatable(config.get(CONF_SOURCE), args, cg.uint8)
+    if source_template_ is not None:
+        cg.add(var.set_source(source_template_))
+
+    vendor_template_ = await cg.templatable(config[CONF_VENDOR_ID], args, cg.uint32)
+    cg.add(var.set_vendor_id(vendor_template_))
+
+    dtype_template_ = await cg.templatable(config[CONF_DEVICE_TYPE], args, cg.uint8)
+    cg.add(var.set_device_type(dtype_template_))
+
+    data_vec_ = cg.std_vector.template(cg.uint8)
+    data_template_ = await cg.templatable(config[CONF_DATA], args, data_vec_, data_vec_)
     cg.add(var.set_data(data_template_))
 
     return var

--- a/components/hdmi_cec/__init__.py
+++ b/components/hdmi_cec/__init__.py
@@ -4,13 +4,25 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins, automation
 from esphome.components import text_sensor
+from esphome.components import binary_sensor
 from esphome.components import button as button_platform
-from esphome.const import CONF_ID, CONF_TRIGGER_ID, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.components import switch as switch_platform
+from esphome.components import number as number_platform
+from esphome.const import (
+    CONF_ID,
+    CONF_NAME,
+    CONF_TRIGGER_ID,
+    CONF_DEVICE_ID,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+)
+from esphome.core import ID, CORE, Define
+from esphome.core.config import Device
+from esphome.helpers import fnv1a_32bit_hash
 
 _LOGGER = logging.getLogger(__name__)
 
 CODEOWNERS = ["@Palakis"]
-AUTO_LOAD = ["text_sensor", "button"]
+AUTO_LOAD = ["text_sensor", "binary_sensor", "button", "switch", "number"]
 
 CONF_PIN = "pin"
 CONF_ADDRESS = "address"
@@ -36,6 +48,12 @@ CONF_SCAN_ON_BOOT = "scan_on_boot"
 CONF_SCAN_BOOT_DELAY = "scan_boot_delay"
 CONF_ON_SCAN_COMPLETE = "on_scan_complete"
 
+CONF_POWER_POLL_INTERVAL = "power_poll_interval"
+CONF_DEVICES = "devices"
+CONF_MATCH = "match"
+CONF_POWER_SWITCH = "power_switch"
+CONF_DEVICE = "device"
+
 DEVICE_TYPES = {
     "tv": 0x00,
     "recording_device": 0x01,
@@ -43,6 +61,133 @@ DEVICE_TYPES = {
     "playback_device": 0x04,
     "audio_system": 0x05,
     "other": 0xFF,
+}
+
+CONTROL_GROUPS = {
+    "navigation_buttons": [
+        ("Select", 0x00, "mdi:circle-outline"),
+        ("Up", 0x01, "mdi:chevron-up"),
+        ("Down", 0x02, "mdi:chevron-down"),
+        ("Left", 0x03, "mdi:chevron-left"),
+        ("Right", 0x04, "mdi:chevron-right"),
+        ("Root Menu", 0x09, "mdi:menu"),
+        ("Back", 0x0D, "mdi:keyboard-backspace"),
+    ],
+    "transport_buttons": [
+        ("Play", 0x44, "mdi:play"),
+        ("Stop", 0x45, "mdi:stop"),
+        ("Pause", 0x46, "mdi:pause"),
+        ("Record", 0x47, "mdi:record"),
+        ("Rewind", 0x48, "mdi:rewind"),
+        ("Fast Forward", 0x49, "mdi:fast-forward"),
+        ("Play/Pause", 0x61, "mdi:play-pause"),
+    ],
+    "volume_buttons": [
+        ("Volume Up", 0x41, "mdi:volume-plus"),
+        ("Volume Down", 0x42, "mdi:volume-minus"),
+        ("Mute", 0x43, "mdi:volume-mute"),
+    ],
+    "power_buttons": [
+        ("Power Toggle", 0x40, "mdi:power"),
+        ("Power Off", 0x6C, "mdi:power-off"),
+        ("Power On", 0x6D, "mdi:power-on"),
+    ],
+    "number_buttons": [
+        ("0", 0x20, "mdi:numeric-0"),
+        ("1", 0x21, "mdi:numeric-1"),
+        ("2", 0x22, "mdi:numeric-2"),
+        ("3", 0x23, "mdi:numeric-3"),
+        ("4", 0x24, "mdi:numeric-4"),
+        ("5", 0x25, "mdi:numeric-5"),
+        ("6", 0x26, "mdi:numeric-6"),
+        ("7", 0x27, "mdi:numeric-7"),
+        ("8", 0x28, "mdi:numeric-8"),
+        ("9", 0x29, "mdi:numeric-9"),
+        ("Dot", 0x2A, "mdi:circle-small"),
+        ("Enter", 0x2B, "mdi:keyboard-return"),
+        ("Clear", 0x2C, "mdi:backspace-outline"),
+        ("Number Entry Mode", 0x1D, "mdi:dialpad"),
+        ("11", 0x1E, "mdi:numeric"),
+        ("12", 0x1F, "mdi:numeric"),
+    ],
+    "channel_buttons": [
+        ("Channel Up", 0x30, "mdi:arrow-up-bold"),
+        ("Channel Down", 0x31, "mdi:arrow-down-bold"),
+        ("Previous Channel", 0x32, "mdi:arrow-u-left-top"),
+    ],
+    "color_buttons": [
+        ("Blue", 0x71, "mdi:square-rounded"),
+        ("Red", 0x72, "mdi:square-rounded"),
+        ("Green", 0x73, "mdi:square-rounded"),
+        ("Yellow", 0x74, "mdi:square-rounded"),
+    ],
+}
+
+# Sensor definitions: key -> (platform_type, setter_name, default_icon, entity_category)
+# "text" = text_sensor, "binary" = binary_sensor
+SENSOR_DEFS = {
+    "osd_name_sensor": (
+        "text",
+        "set_osd_name_sensor",
+        "mdi:label",
+        ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    "device_type_sensor": (
+        "text",
+        "set_device_type_sensor",
+        "mdi:devices",
+        ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    "vendor_id_sensor": (
+        "text",
+        "set_vendor_id_sensor",
+        "mdi:factory",
+        ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    "vendor_name_sensor": (
+        "text",
+        "set_vendor_name_sensor",
+        "mdi:factory",
+        ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    "physical_address_sensor": (
+        "text",
+        "set_physical_address_sensor",
+        "mdi:hdmi-port",
+        ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    "power_status_sensor": ("text", "set_power_status_sensor", "mdi:power", None),
+    "cec_version_sensor": (
+        "text",
+        "set_cec_version_sensor",
+        "mdi:information-outline",
+        ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    "active_source_sensor": (
+        "binary",
+        "set_active_source_sensor",
+        "mdi:video-input-hdmi",
+        None,
+    ),
+    "last_seen_sensor": (
+        "text",
+        "set_last_seen_sensor",
+        "mdi:clock-outline",
+        ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+}
+
+# Human-readable labels for auto-naming entities
+SENSOR_LABELS = {
+    "osd_name_sensor": "OSD Name",
+    "device_type_sensor": "Device Type",
+    "vendor_id_sensor": "Vendor ID",
+    "vendor_name_sensor": "Vendor Name",
+    "physical_address_sensor": "Physical Address",
+    "power_status_sensor": "Power Status",
+    "cec_version_sensor": "CEC Version",
+    "active_source_sensor": "Active Source",
+    "last_seen_sensor": "Last Seen",
 }
 
 
@@ -71,6 +216,9 @@ def validate_osd_name(value):
 
 hdmi_cec_ns = cg.esphome_ns.namespace("hdmi_cec")
 HDMICEC = hdmi_cec_ns.class_("HDMICEC", cg.Component)
+CECRemoteDevice = hdmi_cec_ns.class_("CECRemoteDevice")
+CECControlButton = hdmi_cec_ns.class_("CECControlButton", button_platform.Button)
+CECPowerSwitch = hdmi_cec_ns.class_("CECPowerSwitch", switch_platform.Switch)
 MessageTrigger = hdmi_cec_ns.class_(
     "MessageTrigger",
     automation.Trigger.template(cg.uint8, cg.uint8, cg.std_vector.template(cg.uint8)),
@@ -79,9 +227,85 @@ SendAction = hdmi_cec_ns.class_("SendAction", automation.Action)
 SendToOsdNameAction = hdmi_cec_ns.class_("SendToOsdNameAction", automation.Action)
 SendToPhysicalAddressAction = hdmi_cec_ns.class_("SendToPhysicalAddressAction", automation.Action)
 SendToVendorAndTypeAction = hdmi_cec_ns.class_("SendToVendorAndTypeAction", automation.Action)
+SendToDeviceAction = hdmi_cec_ns.class_("SendToDeviceAction", automation.Action)
 ScanBusAction = hdmi_cec_ns.class_("ScanBusAction", automation.Action)
 ScanCompleteTrigger = hdmi_cec_ns.class_("ScanCompleteTrigger", automation.Trigger.template())
 ScanButton = hdmi_cec_ns.class_("ScanButton", button_platform.Button)
+CECPowerPollNumber = hdmi_cec_ns.class_("CECPowerPollNumber", number_platform.Number, cg.Component)
+
+
+TextSensor = text_sensor.TextSensor
+BinarySensor = binary_sensor.BinarySensor
+
+
+def _build_individual_sensor_schema(sensor_key):
+    platform_type, setter, icon, entity_cat = SENSOR_DEFS[sensor_key]
+    kwargs = {}
+    if icon:
+        kwargs["icon"] = icon
+    if entity_cat:
+        kwargs["entity_category"] = entity_cat
+    if platform_type == "text":
+        return text_sensor.text_sensor_schema(**kwargs)
+    else:
+        return binary_sensor.binary_sensor_schema(**kwargs)
+
+
+_BARE_ENTITY = {"__bare__": True}
+
+
+def _optional_entity(schema):
+    """Accept a full schema dict, or None (bare key like 'power:') to use all defaults."""
+
+    def validator(value):
+        if value is None:
+            return _BARE_ENTITY
+        return schema(value)
+
+    return validator
+
+
+def _is_bare(conf):
+    return isinstance(conf, dict) and conf.get("__bare__") is True
+
+
+def validate_match_criteria(config):
+    match = config.get(CONF_MATCH)
+    if match is None or len(match) == 0:
+        raise cv.Invalid("At least one match criterion is required inside 'match:'")
+    return config
+
+
+MATCH_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_OSD_NAME): cv.string,
+        cv.Optional(CONF_VENDOR_ID): cv.uint32_t,
+        cv.Optional(CONF_DEVICE_TYPE): cv.enum(DEVICE_TYPES, lower=True),
+        cv.Optional(CONF_PHYSICAL_ADDRESS): cv.uint16_t,
+    }
+)
+
+CEC_DEVICE_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(CECRemoteDevice),
+            cv.Required(CONF_NAME): cv.string,
+            cv.Required(CONF_MATCH): MATCH_SCHEMA,
+            # Power switch (accepts bare 'power:' or 'power: {name: ...}')
+            cv.Optional(CONF_POWER_SWITCH): _optional_entity(
+                switch_platform.switch_schema(
+                    CECPowerSwitch,
+                    icon="mdi:power",
+                )
+            ),
+            # Sensor entities (each accepts bare key or full schema)
+            **{cv.Optional(key): _optional_entity(_build_individual_sensor_schema(key)) for key in SENSOR_DEFS},
+            # Control button groups (bare key or true enables the group)
+            **{cv.Optional(group_key): lambda v: True if v is None else cv.boolean(v) for group_key in CONTROL_GROUPS},
+        }
+    ),
+    validate_match_criteria,
+)
 
 
 def validate_address_config(config):
@@ -117,6 +341,14 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_SCAN_ON_BOOT, default=True): cv.boolean,
             cv.Optional(CONF_SCAN_BOOT_DELAY, default="3s"): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_POWER_POLL_INTERVAL, default={"name": "Power Poll Interval"}
+            ): number_platform.number_schema(
+                CECPowerPollNumber,
+                icon="mdi:timer-outline",
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                unit_of_measurement="ms",
+            ),
             cv.Optional(CONF_ON_SCAN_COMPLETE): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ScanCompleteTrigger),
@@ -131,10 +363,39 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_DATA): validate_data_array,
                 }
             ),
+            cv.Optional(CONF_DEVICES): cv.ensure_list(CEC_DEVICE_SCHEMA),
         }
     ),
     validate_address_config,
 )
+
+
+def _update_device_count_define(count_to_add):
+    """Update ESPHOME_DEVICE_COUNT define, adding to any existing value."""
+    existing_count = 0
+    to_remove = None
+    for d in CORE.defines:
+        if isinstance(d, Define) and d.name == "ESPHOME_DEVICE_COUNT":
+            existing_count = d.value
+            to_remove = d
+            break
+    if to_remove is not None:
+        CORE.defines.discard(to_remove)
+    cg.add_define("USE_DEVICES")
+    cg.add_define("ESPHOME_DEVICE_COUNT", existing_count + count_to_add)
+
+
+async def _create_sensor_entity(sensor_key, sensor_conf, device_id_str, remote_dev_var):
+    """Create a text_sensor or binary_sensor entity and bind it to the remote device."""
+    platform_type, setter, icon, entity_cat = SENSOR_DEFS[sensor_key]
+
+    if platform_type == "text":
+        sens = await text_sensor.new_text_sensor(sensor_conf)
+    else:
+        sens = await binary_sensor.new_binary_sensor(sensor_conf)
+
+    cg.add(getattr(remote_dev_var, setter)(sens))
+    return sens
 
 
 async def to_code(config):
@@ -182,6 +443,17 @@ async def to_code(config):
     cg.add(var.set_scan_on_boot(config[CONF_SCAN_ON_BOOT]))
     cg.add(var.set_scan_boot_delay(config[CONF_SCAN_BOOT_DELAY]))
 
+    if CONF_POWER_POLL_INTERVAL in config:
+        num = await number_platform.new_number(
+            config[CONF_POWER_POLL_INTERVAL],
+            min_value=0,
+            max_value=60000,
+            step=100,
+        )
+        await cg.register_component(num, {})
+        cg.add(num.set_parent(var))
+        cg.add(var.set_power_poll_number(num))
+
     for conf in config.get(CONF_ON_SCAN_COMPLETE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
@@ -214,6 +486,113 @@ async def to_code(config):
             ],
             conf,
         )
+
+    # User-defined devices
+    device_configs = config.get(CONF_DEVICES, [])
+    if device_configs:
+        _update_device_count_define(len(device_configs))
+
+    for dev_conf in device_configs:
+        dev_id = dev_conf[CONF_ID]
+        dev_name = dev_conf[CONF_NAME]
+        dev_id_str = str(dev_id.id)
+
+        # Create CECRemoteDevice
+        dev_var = cg.new_Pvariable(dev_id)
+        cg.add(dev_var.set_parent(var))
+        cg.add(dev_var.set_name(dev_name))
+        cg.add(dev_var.set_yaml_id(dev_id_str))
+        cg.add(var.add_remote_device(dev_var))
+
+        # Create ESPHome sub-device for HA grouping
+        sub_device_var_id = ID(f"{dev_id_str}_device", is_declaration=True, type=Device)
+        sub_device_id = cg.new_Pvariable(sub_device_var_id)
+        cg.add(sub_device_id.set_device_id(fnv1a_32bit_hash(dev_id_str)))
+        cg.add(sub_device_id.set_name(dev_name))
+        cg.add(cg.App.register_device(sub_device_id))
+        device_ref = ID(f"{dev_id_str}_device", type=Device)
+
+        # Set match criteria
+        match = dev_conf[CONF_MATCH]
+        if CONF_OSD_NAME in match:
+            cg.add(dev_var.set_match_osd_name(match[CONF_OSD_NAME]))
+        if CONF_VENDOR_ID in match:
+            cg.add(dev_var.set_match_vendor_id(match[CONF_VENDOR_ID]))
+        if CONF_DEVICE_TYPE in match:
+            cg.add(dev_var.set_match_device_type(match[CONF_DEVICE_TYPE]))
+        if CONF_PHYSICAL_ADDRESS in match:
+            cg.add(dev_var.set_match_physical_address(match[CONF_PHYSICAL_ADDRESS]))
+
+        # Helper: ensure entity name is prefixed with device name for HA display
+        def _prefixed_name(name, default_label):
+            """Use the user-provided name if set, otherwise auto-generate '{dev_name} {label}'."""
+            if name:
+                return name
+            return f"{dev_name} {default_label}"
+
+        # Collect all sensors to create (individual keys + shorthand list)
+        sensors_to_create = {}
+
+        # Individual sensor entities (full schema — may have user name or be bare)
+        for sensor_key in SENSOR_DEFS:
+            if sensor_key in dev_conf:
+                raw_conf = dev_conf[sensor_key]
+                label = SENSOR_LABELS[sensor_key]
+                sensor_id_str = f"{dev_id_str}_{sensor_key}"
+                platform_type = SENSOR_DEFS[sensor_key][0]
+                if _is_bare(raw_conf):
+                    schema = _build_individual_sensor_schema(sensor_key)
+                    sensor_conf = schema({CONF_NAME: f"{dev_name} {label}"})
+                else:
+                    sensor_conf = dict(raw_conf)
+                    sensor_conf[CONF_NAME] = _prefixed_name(sensor_conf.get(CONF_NAME), label)
+                # Ensure unique ID
+                if platform_type == "text":
+                    sensor_conf[CONF_ID] = ID(sensor_id_str, is_declaration=True, type=text_sensor.TextSensor)
+                else:
+                    sensor_conf[CONF_ID] = ID(
+                        sensor_id_str,
+                        is_declaration=True,
+                        type=binary_sensor.BinarySensor,
+                    )
+                sensor_conf[CONF_DEVICE_ID] = device_ref
+                sensors_to_create[sensor_key] = sensor_conf
+
+        # Create all sensor entities
+        for sensor_key, sensor_conf in sensors_to_create.items():
+            await _create_sensor_entity(sensor_key, sensor_conf, dev_id_str, dev_var)
+
+        # Power switch
+        if CONF_POWER_SWITCH in dev_conf:
+            raw_power = dev_conf[CONF_POWER_SWITCH]
+            if _is_bare(raw_power):
+                power_schema = switch_platform.switch_schema(CECPowerSwitch, icon="mdi:power")
+                power_conf = power_schema({CONF_NAME: f"{dev_name} Power"})
+            else:
+                power_conf = dict(raw_power)
+                power_conf[CONF_NAME] = _prefixed_name(power_conf.get(CONF_NAME), "Power")
+            power_conf[CONF_ID] = ID(f"{dev_id_str}_power", is_declaration=True, type=CECPowerSwitch)
+            power_conf[CONF_DEVICE_ID] = device_ref
+            sw = await switch_platform.new_switch(power_conf)
+            cg.add(sw.set_parent(var))
+            cg.add(sw.set_remote_device(dev_var))
+            cg.add(dev_var.set_power_switch(sw))
+
+        # Control button groups
+        for group_name, buttons in CONTROL_GROUPS.items():
+            if not dev_conf.get(group_name):
+                continue
+            for btn_name, ui_code, btn_icon in buttons:
+                safe_name = btn_name.lower().replace("/", "_").replace(" ", "_")
+                btn_id_str = f"{dev_id_str}_{safe_name}"
+                btn_schema = button_platform.button_schema(CECControlButton, icon=btn_icon)
+                btn_conf = btn_schema({CONF_NAME: f"{dev_name} {btn_name}"})
+                btn_conf[CONF_ID] = ID(btn_id_str, is_declaration=True, type=CECControlButton)
+                btn_conf[CONF_DEVICE_ID] = device_ref
+                btn = await button_platform.new_button(btn_conf)
+                cg.add(btn.set_parent(var))
+                cg.add(btn.set_remote_device(dev_var))
+                cg.add(btn.set_ui_command(ui_code))
 
 
 @automation.register_action(
@@ -336,6 +715,34 @@ async def send_to_vendor_and_type_action_to_code(config, action_id, template_arg
 
     dtype_template_ = await cg.templatable(config[CONF_DEVICE_TYPE], args, cg.uint8)
     cg.add(var.set_device_type(dtype_template_))
+
+    data_vec_ = cg.std_vector.template(cg.uint8)
+    data_template_ = await cg.templatable(config[CONF_DATA], args, data_vec_, data_vec_)
+    cg.add(var.set_data(data_template_))
+
+    return var
+
+
+@automation.register_action(
+    "hdmi_cec.send_to_device",
+    SendToDeviceAction,
+    {
+        cv.GenerateID(CONF_PARENT): cv.use_id(HDMICEC),
+        cv.Optional(CONF_SOURCE): cv.templatable(cv.int_range(min=0, max=15)),
+        cv.Required(CONF_DEVICE): cv.use_id(CECRemoteDevice),
+        cv.Required(CONF_DATA): cv.templatable(validate_data_array),
+    },
+)
+async def send_to_device_action_to_code(config, action_id, template_args, args):
+    parent = await cg.get_variable(config[CONF_PARENT])
+    var = cg.new_Pvariable(action_id, template_args, parent)
+
+    source_template_ = await cg.templatable(config.get(CONF_SOURCE), args, cg.uint8)
+    if source_template_ is not None:
+        cg.add(var.set_source(source_template_))
+
+    device = await cg.get_variable(config[CONF_DEVICE])
+    cg.add(var.set_device(device))
 
     data_vec_ = cg.std_vector.template(cg.uint8)
     data_template_ = await cg.templatable(config[CONF_DATA], args, data_vec_, data_vec_)

--- a/components/hdmi_cec/cec_decoder.cpp
+++ b/components/hdmi_cec/cec_decoder.cpp
@@ -65,7 +65,7 @@ const std::array<const char *, 0x77> Decoder::UI_Commands = {
     "Previous Channel",
     "Sound Select",
     "Input Select",
-    "isplay Information",
+    "Display Information",
     "Help",
     "Page Up",
     /* 0x38 = */ "Page Down",
@@ -155,12 +155,9 @@ template<uint32_t OPERANDS> bool Decoder::do_operand() {
 template<> bool Decoder::do_operand<Decoder::None>() { return append_operand(""); }
 
 template<> bool Decoder::do_operand<Decoder::AbortReason>() {
-  const static std::array<const char *, 7> names = {"Unrecognized opcode",
-                                                    "Not in correct mode to respond",
-                                                    "Cannot provide source",
-                                                    "Invalid operand",
-                                                    "Refused",
-                                                    "Unable to determine"};
+  const static std::array<const char *, 7> names = {
+      "Unrecognized opcode", "Not in correct mode to respond", "Cannot provide source", "Invalid operand", "Refused",
+      "Unable to determine"};
   return append_operand<names.size()>(names);
 }
 
@@ -185,15 +182,14 @@ template<> bool Decoder::do_operand<Decoder::AudioStatus>() {
 }
 
 template<> bool Decoder::do_operand<Decoder::DeviceType>() {
-  const static std::array<const char *, 9> names = {"TV]",           "Recording Device]", "Reserved",
-                                                    "Tuner",       "Playback Device", "Audio System",
-                                                    "Pure CEC Switch", "Video Processor"};
+  const static std::array<const char *, 9> names = {
+      "TV",           "Recording Device", "Reserved",       "Tuner", "Playback Device",
+      "Audio System", "Pure CEC Switch",  "Video Processor"};
   return append_operand<names.size()>(names);
 }
 
 template<> bool Decoder::do_operand<Decoder::DisplayControl>() {
-  const static std::array<const char *, 9> names = {"Default Time", "Until cleared", "Clear previous",
-                                                    "Reserved"};
+  const static std::array<const char *, 9> names = {"Default Time", "Until cleared", "Clear previous", "Reserved"};
   return append_operand<names.size()>(names);
 }
 
@@ -376,7 +372,6 @@ const Decoder::CecOpcodeTable Decoder::cec_opcode_table = {
     {0x45, {"User Control Released", &Decoder::do_operand<None>}},
     {0x8F, {"Give Device Power Status", &Decoder::do_operand<None>}},
     {0x90, {"Report Power Status", &Decoder::do_operand<PowerStatus>}},
-    {0x00, {"Feature Abort", &Decoder::do_operand<Two(FeatureOpcode, AbortReason)>}},
     {0xFF, {"Abort", &Decoder::do_operand<None>}},
     {0x71, {"Give Audio Status", &Decoder::do_operand<None>}},
     {0x7D, {"Give System Audio Mode Status", &Decoder::do_operand<None>}},
@@ -396,13 +391,13 @@ const Decoder::CecOpcodeTable Decoder::cec_opcode_table = {
     {0xF8, {"CDC Message", &Decoder::do_operand<None>}}};
 
 const std::map<uint32_t, const char *> Decoder::vendor_ids = {
-    {0x000039, "Toshiba"}, {0x0000F0, "Samsung"},     {0x0005CD, "Denon"},         {0x000678, "Maranz"},
+    {0x000039, "Toshiba"}, {0x0000F0, "Samsung"},     {0x0005CD, "Denon"},         {0x000678, "Marantz"},
     {0x000982, "Loewe"},   {0x0009B0, "Onkyo"},       {0x000CB8, "Medion"},        {0x000CE7, "Toshiba"},
     {0x0010FA, "Apple"},   {0x001582, "Pulse Eight"}, {0x001950, "Harman Kardon"}, {0x001A11, "Google"},
     {0x0020C7, "Akai"},    {0x002467, "AOC"},         {0x008045, "Panasonic"},     {0x00903E, "Philips"},
     {0x009053, "Daewoo"},  {0x00A0DE, "Yamaha"},      {0x00D0D5, "Grundig"},       {0x00E036, "Pioneer"},
     {0x00E091, "LG"},      {0x08001F, "Sharp"},       {0x080046, "Sony"},          {0x18C086, "Broadcom"},
-    {0x534850, "Sharp"},   {0x6B746D, "Vizio"},       {0x8065E9, "Benq"},          {0x9C645E, "Harman Kardon"}};
+    {0x534850, "Sharp"},   {0x6B746D, "Vizio"},       {0x8065E9, "BenQ"},          {0x9C645E, "Harman Kardon"}};
 
 std::string Decoder::address_decode() const {
   const static std::array<const char *, 16> names = {"TV",           "RecordingDev1", "RecordingDev2", "Tuner1",

--- a/components/hdmi_cec/cec_decoder.cpp
+++ b/components/hdmi_cec/cec_decoder.cpp
@@ -1,12 +1,12 @@
+#include "cec_decoder.h"
+
+#include <array>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <map>
-#include <array>
-#include <cstdio>
 
 #include "hdmi_cec.h"
-#include "cec_decoder.h"
 
 namespace esphome {
 namespace hdmi_cec {
@@ -224,7 +224,7 @@ template<> bool Decoder::do_operand<Decoder::PhysicalAddress>() {
   }
   char line[12];
   std::sprintf(line, "%1x.%1x.%1x.%1x", (frame_[offset_] >> 4) & 0xF, frame_[offset_] & 0xF,
-    (frame_[offset_ + 1] >> 4) & 0xF, frame_[offset_ + 1] & 0xF);
+               (frame_[offset_ + 1] >> 4) & 0xF, frame_[offset_ + 1] & 0xF);
   return append_operand(line, 2);
 }
 
@@ -405,10 +405,11 @@ const std::map<uint32_t, const char *> Decoder::vendor_ids = {
     {0x534850, "Sharp"},   {0x6B746D, "Vizio"},       {0x8065E9, "Benq"},          {0x9C645E, "Harman Kardon"}};
 
 std::string Decoder::address_decode() const {
-  const static std::array<const char *, 16> names = { "TV", "RecordingDev1", "RecordingDev2", "Tuner1",
-    "PlaybackDev1", "AudioSystem", "Tuner2", "Tuner3", "PlaybackDev2", "RecordingDev3",
-    "Tuner4", "PlaybackDev3", "Reserved", "Reserved", "SpecificUse", "Unregistered"};
-  const char* dest = (frame_.is_broadcast()) ? "All" : names[frame_.destination_addr()];
+  const static std::array<const char *, 16> names = {"TV",           "RecordingDev1", "RecordingDev2", "Tuner1",
+                                                     "PlaybackDev1", "AudioSystem",   "Tuner2",        "Tuner3",
+                                                     "PlaybackDev2", "RecordingDev3", "Tuner4",        "PlaybackDev3",
+                                                     "Reserved",     "Reserved",      "SpecificUse",   "Unregistered"};
+  const char *dest = (frame_.is_broadcast()) ? "All" : names[frame_.destination_addr()];
   return std::string(names[frame_.initiator_addr()]) + " to " + dest + ": ";
 }
 
@@ -420,15 +421,15 @@ const char *Decoder::find_opcode_name(uint32_t opcode) const {
   return it->second.name;
 }
 
-  /**
-   * Helper function to implement the 'do_operand' methods, to gather a textual representation.
-   * @return true if a further operand can be decoded, false otherwise
-   */
-  bool Decoder::append_operand(const char *word, uint8_t offset_incr /* default 1 */) {
-    length_ += snprintf(&line_[length_], (line_.size() - length_), "[%s]", word);
-    offset_ += offset_incr;
-    return (length_ < line_.size()) && (offset_ < frame_.size());
-  }
+/**
+ * Helper function to implement the 'do_operand' methods, to gather a textual representation.
+ * @return true if a further operand can be decoded, false otherwise
+ */
+bool Decoder::append_operand(const char *word, uint8_t offset_incr /* default 1 */) {
+  length_ += snprintf(&line_[length_], (line_.size() - length_), "[%s]", word);
+  offset_ += offset_incr;
+  return (length_ < line_.size()) && (offset_ < frame_.size());
+}
 
 /**
  * Entry function 'decode' to call for full decode of a CEC frame
@@ -450,9 +451,9 @@ std::string Decoder::decode() {
 
   result += std::string("<") + it->second.name + ">";
   // operand fields
-  length_ = 0;  // currently accumulated length of text of operands
+  length_ = 0;         // currently accumulated length of text of operands
   line_[length_] = 0;  // initialise operand text to empty string
-  offset_ = 2;  // location in frame of first operand to decode
+  offset_ = 2;         // location in frame of first operand to decode
   OperandDecode_f f = it->second.decode_f;
   (this->*f)();
   result += &line_[0];

--- a/components/hdmi_cec/cec_decoder.cpp
+++ b/components/hdmi_cec/cec_decoder.cpp
@@ -1,143 +1,167 @@
 #include "cec_decoder.h"
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <map>
 
 #include "hdmi_cec.h"
 
 namespace esphome {
 namespace hdmi_cec {
 
-const std::array<const char *, 0x77> Decoder::UI_Commands = {
-    /* 0x00 = */ "Select",
-    "Up",
-    "Down",
-    "Left",
-    "Right",
-    "Right-Up",
-    "Right-Down",
-    "Left-Up",
-    /* 0x08 = */ "Left-Down",
-    "Root Menu",
-    "Setup Menu",
-    "Contents Menu",
-    "Favorite Menu",
-    "Exit",
-    "Reserved",
-    "Reserved",
-    /* 0x10 = */ "Media Top Menu",
-    "Media Context-sensitive Menu",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    /* 0x18 = */ "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    "Number Entry Mode",
-    "11",
-    "12",
-    /* 0x20 = */ "0",
-    "1",
-    "2",
-    "3",
-    "4",
-    "5",
-    "6",
-    "7",
-    /* 0x28 = */ "8",
-    "9",
-    "Dot",
-    "Enter",
-    "Clear",
-    "Reserved",
-    "Reserved",
-    "Next Favorite",
-    /* 0x30 = */ "Channel Up",
-    "Channel Down",
-    "Previous Channel",
-    "Sound Select",
-    "Input Select",
-    "Display Information",
-    "Help",
-    "Page Up",
-    /* 0x38 = */ "Page Down",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    /* 0x40 = */ "Power",
-    "Volume Up",
-    "Volume Down",
-    "Mute",
-    "Play",
-    "Stop",
-    "Pause",
-    "Record",
-    /* 0x48 = */ "Rewind",
-    "Fast forward",
-    "Eject",
-    "Forward",
-    "Backward",
-    "Stop-Record",
-    "Pause-Record",
-    "Reserved",
-    /* 0x50 = */ "Angle",
-    "Sub picture",
-    "Video on Demand",
-    "Electronic Program Guide",
-    "Timer Programming",
-    "Initial Configuration",
-    "Select Broadcast Type",
-    "Select Sound Presentation",
-    /* 0x58 = */ "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    "Reserved",
-    /* 0x60 = */ "Play Function",
-    "Pause-Play Function",
-    "Record Function",
-    "Pause-Record Function",
-    "Stop Function",
-    "Mute Function",
-    "Restore Volume Function",
-    "Tune Function",
-    /* 0x68 = */ "Select Media Function",
-    "Select A/V Input Function",
-    "Select Audio Input Function",
-    "Power Toggle Function",
-    "Power Off Function",
-    "Power On Function",
-    "Reserved",
-    "Reserved",
-    /* 0x70 = */ "Reserved",
-    "F1 (Blue)",
-    "F2 (Red)",
-    "F3 (Green)",
-    "F4 (Yellow)",
-    "F5",
-    "Data"};
+static const std::array<const char *, 0x77> UI_COMMANDS = {
+    "Select",                        // 0x00
+    "Up",                            // 0x01
+    "Down",                          // 0x02
+    "Left",                          // 0x03
+    "Right",                         // 0x04
+    "Right-Up",                      // 0x05
+    "Right-Down",                    // 0x06
+    "Left-Up",                       // 0x07
+    "Left-Down",                     // 0x08
+    "Root Menu",                     // 0x09
+    "Setup Menu",                    // 0x0A
+    "Contents Menu",                 // 0x0B
+    "Favorite Menu",                 // 0x0C
+    "Exit",                          // 0x0D
+    "Reserved",                      // 0x0E
+    "Reserved",                      // 0x0F
+    "Media Top Menu",                // 0x10
+    "Media Context-sensitive Menu",  // 0x11
+    "Reserved",                      // 0x12
+    "Reserved",                      // 0x13
+    "Reserved",                      // 0x14
+    "Reserved",                      // 0x15
+    "Reserved",                      // 0x16
+    "Reserved",                      // 0x17
+    "Reserved",                      // 0x18
+    "Reserved",                      // 0x19
+    "Reserved",                      // 0x1A
+    "Reserved",                      // 0x1B
+    "Reserved",                      // 0x1C
+    "Number Entry Mode",             // 0x1D
+    "11",                            // 0x1E
+    "12",                            // 0x1F
+    "0",                             // 0x20
+    "1",                             // 0x21
+    "2",                             // 0x22
+    "3",                             // 0x23
+    "4",                             // 0x24
+    "5",                             // 0x25
+    "6",                             // 0x26
+    "7",                             // 0x27
+    "8",                             // 0x28
+    "9",                             // 0x29
+    "Dot",                           // 0x2A
+    "Enter",                         // 0x2B
+    "Clear",                         // 0x2C
+    "Reserved",                      // 0x2D
+    "Reserved",                      // 0x2E
+    "Next Favorite",                 // 0x2F
+    "Channel Up",                    // 0x30
+    "Channel Down",                  // 0x31
+    "Previous Channel",              // 0x32
+    "Sound Select",                  // 0x33
+    "Input Select",                  // 0x34
+    "Display Information",           // 0x35
+    "Help",                          // 0x36
+    "Page Up",                       // 0x37
+    "Page Down",                     // 0x38
+    "Reserved",                      // 0x39
+    "Reserved",                      // 0x3A
+    "Reserved",                      // 0x3B
+    "Reserved",                      // 0x3C
+    "Reserved",                      // 0x3D
+    "Reserved",                      // 0x3E
+    "Reserved",                      // 0x3F
+    "Power",                         // 0x40
+    "Volume Up",                     // 0x41
+    "Volume Down",                   // 0x42
+    "Mute",                          // 0x43
+    "Play",                          // 0x44
+    "Stop",                          // 0x45
+    "Pause",                         // 0x46
+    "Record",                        // 0x47
+    "Rewind",                        // 0x48
+    "Fast forward",                  // 0x49
+    "Eject",                         // 0x4A
+    "Forward",                       // 0x4B
+    "Backward",                      // 0x4C
+    "Stop-Record",                   // 0x4D
+    "Pause-Record",                  // 0x4E
+    "Reserved",                      // 0x4F
+    "Angle",                         // 0x50
+    "Sub picture",                   // 0x51
+    "Video on Demand",               // 0x52
+    "Electronic Program Guide",      // 0x53
+    "Timer Programming",             // 0x54
+    "Initial Configuration",         // 0x55
+    "Select Broadcast Type",         // 0x56
+    "Select Sound Presentation",     // 0x57
+    "Reserved",                      // 0x58
+    "Reserved",                      // 0x59
+    "Reserved",                      // 0x5A
+    "Reserved",                      // 0x5B
+    "Reserved",                      // 0x5C
+    "Reserved",                      // 0x5D
+    "Reserved",                      // 0x5E
+    "Reserved",                      // 0x5F
+    "Play Function",                 // 0x60
+    "Pause-Play Function",           // 0x61
+    "Record Function",               // 0x62
+    "Pause-Record Function",         // 0x63
+    "Stop Function",                 // 0x64
+    "Mute Function",                 // 0x65
+    "Restore Volume Function",       // 0x66
+    "Tune Function",                 // 0x67
+    "Select Media Function",         // 0x68
+    "Select A/V Input Function",     // 0x69
+    "Select Audio Input Function",   // 0x6A
+    "Power Toggle Function",         // 0x6B
+    "Power Off Function",            // 0x6C
+    "Power On Function",             // 0x6D
+    "Reserved",                      // 0x6E
+    "Reserved",                      // 0x6F
+    "Reserved",                      // 0x70
+    "F1 (Blue)",                     // 0x71
+    "F2 (Red)",                      // 0x72
+    "F3 (Green)",                    // 0x73
+    "F4 (Yellow)",                   // 0x74
+    "F5",                            // 0x75
+    "Data",                          // 0x76
+};
 
 // See 'short audio descriptor' in https://en.wikipedia.org/wiki/Extended_Display_Identification_Data
-const std::array<const char *, 0x11> Decoder::audio_formats = {
-    "reserved", "LPCM", "AC3",    "MPEG-1",           "MP3",       "MPEG-2",  "AAC",       "DTS", "ATRAC",
-    "DSD",      "DD+",  "DTS-HD", "MAT/Dolby TrueHD", "DST Audio", "WMA Pro", "Extension?"};
-const std::array<const char *, 8> Decoder::audio_samplerates = {"32", "44.1", "48",  "88",
-                                                                "96", "176",  "192", "Reserved"};
+static const std::array<const char *, 0x11> AUDIO_FORMATS = {
+    "reserved",          // 0x00
+    "LPCM",              // 0x01
+    "AC3",               // 0x02
+    "MPEG-1",            // 0x03
+    "MP3",               // 0x04
+    "MPEG-2",            // 0x05
+    "AAC",               // 0x06
+    "DTS",               // 0x07
+    "ATRAC",             // 0x08
+    "DSD",               // 0x09
+    "DD+",               // 0x0A
+    "DTS-HD",            // 0x0B
+    "MAT/Dolby TrueHD",  // 0x0C
+    "DST Audio",         // 0x0D
+    "WMA Pro",           // 0x0E
+    "Extension?",        // 0x0F
+};
+static const std::array<const char *, 8> AUDIO_SAMPLERATES = {
+    "32",        // 0 (bit 0)
+    "44.1",      // 1 (bit 1)
+    "48",        // 2 (bit 2)
+    "88",        // 3 (bit 3)
+    "96",        // 4 (bit 4)
+    "176",       // 5 (bit 5)
+    "192",       // 6 (bit 6)
+    "Reserved",  // 7 (bit 7)
+};
 
 template<uint32_t OPERANDS> bool Decoder::do_operand() {
   if (OPERANDS <= 0xFF) {
@@ -165,7 +189,7 @@ template<> bool Decoder::do_operand<Decoder::AudioFormat>() {
   // this type of operand comes in a sequence, until exhausted
   bool ok = true;
   while (ok && (offset_ < frame_.size())) {
-    ok = append_operand<audio_formats.size()>(audio_formats);
+    ok = append_operand<AUDIO_FORMATS.size()>(AUDIO_FORMATS);
   }
   return ok;
 }
@@ -181,11 +205,27 @@ template<> bool Decoder::do_operand<Decoder::AudioStatus>() {
   }
 }
 
+const char *Decoder::find_device_type_name(uint8_t type) {
+  // clang-format off
+  static const char *names[] = {
+      "TV",               // 0x00
+      "Recording Device", // 0x01
+      "Reserved",         // 0x02
+      "Tuner",            // 0x03
+      "Playback Device",  // 0x04
+      "Audio System",     // 0x05
+      "Pure CEC Switch",  // 0x06
+      "Video Processor",  // 0x07
+  };
+  // clang-format on
+  if (type < sizeof(names) / sizeof(names[0]))
+    return names[type];
+  return nullptr;
+}
+
 template<> bool Decoder::do_operand<Decoder::DeviceType>() {
-  const static std::array<const char *, 9> names = {
-      "TV",           "Recording Device", "Reserved",       "Tuner", "Playback Device",
-      "Audio System", "Pure CEC Switch",  "Video Processor"};
-  return append_operand<names.size()>(names);
+  const char *name = find_device_type_name(frame_[offset_]);
+  return append_operand(name ? name : "?");
 }
 
 template<> bool Decoder::do_operand<Decoder::DisplayControl>() {
@@ -224,9 +264,21 @@ template<> bool Decoder::do_operand<Decoder::PhysicalAddress>() {
   return append_operand(line, 2);
 }
 
+const char *Decoder::find_power_status_name(uint8_t status) {
+  static const char *names[] = {
+      "On",             // 0x00
+      "Standby",        // 0x01
+      "Standby to On",  // 0x02
+      "On to Standby",  // 0x03
+  };
+  if (status < sizeof(names) / sizeof(names[0]))
+    return names[status];
+  return nullptr;
+}
+
 template<> bool Decoder::do_operand<Decoder::PowerStatus>() {
-  const static std::array<const char *, 5> names = {"On", "Standby", "Standby->On", "On->Standby"};
-  return append_operand<names.size()>(names);
+  const char *name = find_power_status_name(frame_[offset_]);
+  return append_operand(name ? name : "?");
 }
 
 template<> bool Decoder::do_operand<Decoder::ShortAudioDescriptor>() {
@@ -238,13 +290,13 @@ template<> bool Decoder::do_operand<Decoder::ShortAudioDescriptor>() {
   while (ok && (offset_ + 2 < frame_.size())) {
     const uint8_t *descriptor = frame_.data() + offset_;
     uint8_t format = (descriptor[0] >> 3) & 0x0F;
-    pos = std::sprintf(&line[0], "%s", audio_formats[format]);
+    pos = std::sprintf(&line[0], "%s", AUDIO_FORMATS[format]);
     pos += std::sprintf(&line[pos], ",num_channels=%d", (descriptor[0] & 0x07));
     uint8_t rates = descriptor[1];
     for (int bit = 0; rates; bit++, rates >>= 1) {
       if (rates & 0x1) {
         // show support of various audio sample rates
-        pos += std::sprintf(&line[pos], ",%skHz", audio_samplerates[bit]);
+        pos += std::sprintf(&line[pos], ",%skHz", AUDIO_SAMPLERATES[bit]);
       }
     }
     if (format == 1) {
@@ -270,7 +322,7 @@ template<> bool Decoder::do_operand<Decoder::SystemAudioStatus>() {
 
 template<> bool Decoder::do_operand<Decoder::UICommand>() {
   uint8_t command = frame_[offset_];
-  bool ok = append_operand<UI_Commands.size()>(UI_Commands);
+  bool ok = append_operand<UI_COMMANDS.size()>(UI_COMMANDS);
   if (!ok) {
     return false;
   }
@@ -300,122 +352,192 @@ template<> bool Decoder::do_operand<Decoder::VendorId>() {
     return append_operand("?", 3);
   }
   uint32_t id = (uint32_t) (frame_[offset_]) << 16 | (uint32_t) (frame_[offset_ + 1]) << 8 | frame_[offset_ + 2];
-  auto it = vendor_ids.find(id);
-  if (it == vendor_ids.end()) {
+  const char *name = find_vendor_name(id);
+  if (name == nullptr) {
     // if the hdmi-cec vendor id is not in our list, the id value itself is printed.
     char line[12];
     sprintf(line, "ID=%06x", id);
     return append_operand(line, 3);
   }
-  return append_operand(it->second, 3);
+  return append_operand(name, 3);
+}
+
+const char *Decoder::find_cec_version_name(uint8_t version) {
+  static const char *names[] = {
+      "1.1",   // 0x00
+      "1.2",   // 0x01
+      "1.2a",  // 0x02
+      "1.3",   // 0x03
+      "1.3a",  // 0x04
+      "1.4",   // 0x05
+      "2.0",   // 0x06
+      "2.x",   // 0x07
+      "2.x",   // 0x08
+  };
+  if (version < sizeof(names) / sizeof(names[0]))
+    return names[version];
+  return nullptr;
 }
 
 template<> bool Decoder::do_operand<Decoder::CecVersion>() {
-  const static std::array<const char *, 9> names = {"?", "1.2", "1.2a", "1.3", "1.3a", "1.4", "2.0", "2.x", "2.x"};
-  return append_operand<names.size()>(names);
+  const char *name = find_cec_version_name(frame_[offset_]);
+  return append_operand(name ? name : "?");
 }
 
-const Decoder::CecOpcodeTable Decoder::cec_opcode_table = {
-    // opcode,   name,       operands
-    {0x04, {"Image View On", &Decoder::do_operand<None>}},
-    {0x00, {"Feature Abort", &Decoder::do_operand<Two(FeatureOpcode, AbortReason)>}},
-    {0x0D, {"Text View On", &Decoder::do_operand<None>}},
-    {0x82, {"Active Source", &Decoder::do_operand<PhysicalAddress>}},
-    {0x9D, {"Inactive Source", &Decoder::do_operand<PhysicalAddress>}},
-    {0x85, {"Request Active Source", &Decoder::do_operand<None>}},
-    {0x80, {"Routing Change", &Decoder::do_operand<Two(PhysicalAddress, PhysicalAddress)>}},
-    {0x81, {"Routing Information", &Decoder::do_operand<PhysicalAddress>}},
-    {0x86, {"Set Stream Path", &Decoder::do_operand<PhysicalAddress>}},
-    {0x36, {"Standby", &Decoder::do_operand<None>}},
-    {0x0B, {"Record Off", &Decoder::do_operand<None>}},
-    {0x09, {"Record On", &Decoder::do_operand<RecordSource>}},
-    {0x0A, {"Record Status", &Decoder::do_operand<RecordStatusInfo>}},
-    {0x0F, {"Record TV Screen", &Decoder::do_operand<None>}},
-    {0x33, {"Clear Analogue Timer", &Decoder::do_operand<Two(StartDateTime, Duration)>}},
-    {0x99, {"Clear Digital Timer", &Decoder::do_operand<Two(StartDateTime, Duration)>}},
-    {0xA1, {"Clear External Timer", &Decoder::do_operand<Two(StartDateTime, Duration)>}},
-    {0x34, {"Set Analogue Timer", &Decoder::do_operand<Two(StartDateTime, Duration)>}},
-    {0x97, {"Set Digital Timer", &Decoder::do_operand<Two(StartDateTime, Duration)>}},
-    {0xA2, {"Set External Timer", &Decoder::do_operand<Two(StartDateTime, Duration)>}},
-    {0x67, {"Set Timer Program Title", &Decoder::do_operand<ProgramTitleString>}},
-    {0x43, {"Timer Cleared Status", &Decoder::do_operand<TimerClearedStatusData>}},
-    {0x35, {"Timer Status", &Decoder::do_operand<TimerStatusData>}},
-    {0x9E, {"CEC Version", &Decoder::do_operand<CecVersion>}},
-    {0x9F, {"Get CEC Version", &Decoder::do_operand<None>}},
-    {0x83, {"Give Physical Address", &Decoder::do_operand<None>}},
-    {0x91, {"Get Menu Language", &Decoder::do_operand<None>}},
-    {0x84, {"Report Physical Address", &Decoder::do_operand<Two(PhysicalAddress, DeviceType)>}},
-    {0x32, {"Set Menu Language", &Decoder::do_operand<Language>}},
-    {0x42, {"Deck Control", &Decoder::do_operand<DeckControlMode>}},
-    {0x1B, {"Deck Status", &Decoder::do_operand<DeckInfo>}},
-    {0x1A, {"Give Deck Status", &Decoder::do_operand<StatusRequest>}},
-    {0x41, {"Play", &Decoder::do_operand<PlayMode>}},
-    {0x08, {"Give Tuner Device Status", &Decoder::do_operand<StatusRequest>}},
-    {0x92,
-     {"Select Analogue Service", &Decoder::do_operand<Three(AnalogBroadcastType, AnalogFrequency, BroadcastSystem)>}},
-    {0x93, {"Select Digital Service", &Decoder::do_operand<DigitalServiceIdentification>}},
-    {0x07, {"Tuner Device Status", &Decoder::do_operand<TunerDeviceInfo>}},
-    {0x06, {"Tuner Step Decrement", &Decoder::do_operand<None>}},
-    {0x05, {"Tuner Step Increment", &Decoder::do_operand<None>}},
-    {0x87, {"Device Vendor ID", &Decoder::do_operand<VendorId>}},
-    {0x8C, {"Give Device Vendor ID", &Decoder::do_operand<None>}},
-    {0x89, {"Vendor Command", &Decoder::do_operand<VendorSpecificData>}},
-    {0xA0, {"Vendor Command With ID", &Decoder::do_operand<Two(VendorId, VendorSpecificData)>}},
-    {0x8A, {"Vendor Remote Button Down", &Decoder::do_operand<VendorSpecificRCCode>}},
-    {0x8B, {"Vendor Remote Button Up", &Decoder::do_operand<None>}},
-    {0x64, {"Set OSD String", &Decoder::do_operand<Two(DisplayControl, OsdString)>}},
-    {0x46, {"Give OSD Name", &Decoder::do_operand<None>}},
-    {0x47, {"Set OSD Name", &Decoder::do_operand<OsdName>}},
-    {0x8D, {"Menu Request", &Decoder::do_operand<MenuRequestType>}},
-    {0x8E, {"Menu Status", &Decoder::do_operand<MenuState>}},
-    {0x44, {"User Control Pressed", &Decoder::do_operand<UICommand>}},
-    {0x45, {"User Control Released", &Decoder::do_operand<None>}},
-    {0x8F, {"Give Device Power Status", &Decoder::do_operand<None>}},
-    {0x90, {"Report Power Status", &Decoder::do_operand<PowerStatus>}},
-    {0xFF, {"Abort", &Decoder::do_operand<None>}},
-    {0x71, {"Give Audio Status", &Decoder::do_operand<None>}},
-    {0x7D, {"Give System Audio Mode Status", &Decoder::do_operand<None>}},
-    {0x7A, {"Report Audio Status", &Decoder::do_operand<AudioStatus>}},
-    {0xA3, {"Report Short Audio Descriptor", &Decoder::do_operand<ShortAudioDescriptor>}},
-    {0xA4, {"Request Short Audio Descriptor", &Decoder::do_operand<AudioFormat>}},
-    {0x72, {"Set System Audio Mode", &Decoder::do_operand<SystemAudioStatus>}},
-    {0x70, {"System Audio Mode Request", &Decoder::do_operand<PhysicalAddress>}},
-    {0x7E, {"System Audio Mode Status", &Decoder::do_operand<SystemAudioStatus>}},
-    {0x9A, {"Set Audio Rate", &Decoder::do_operand<AudioRate>}},
-    {0xC0, {"Initiate ARC", &Decoder::do_operand<None>}},
-    {0xC1, {"Report ARC Initiated", &Decoder::do_operand<None>}},
-    {0xC2, {"Report ARC Terminated", &Decoder::do_operand<None>}},
-    {0xC3, {"Request ARC Initiation", &Decoder::do_operand<None>}},
-    {0xC4, {"Request ARC Termination", &Decoder::do_operand<None>}},
-    {0xC5, {"Terminate ARC", &Decoder::do_operand<None>}},
-    {0xF8, {"CDC Message", &Decoder::do_operand<None>}}};
+const Decoder::FrameType *Decoder::find_opcode(uint8_t opcode) {
+  struct Entry {
+    uint8_t opcode;
+    FrameType type;
+  };
+  // Sorted by opcode for binary search
+  static constexpr Entry table[] = {
+      {0x00, {"Feature Abort", &Decoder::do_operand<Two(FeatureOpcode, AbortReason)>}},
+      {0x04, {"Image View On", &Decoder::do_operand<None>}},
+      {0x05, {"Tuner Step Increment", &Decoder::do_operand<None>}},
+      {0x06, {"Tuner Step Decrement", &Decoder::do_operand<None>}},
+      {0x07, {"Tuner Device Status", &Decoder::do_operand<TunerDeviceInfo>}},
+      {0x08, {"Give Tuner Device Status", &Decoder::do_operand<StatusRequest>}},
+      {0x09, {"Record On", &Decoder::do_operand<RecordSource>}},
+      {0x0A, {"Record Status", &Decoder::do_operand<RecordStatusInfo>}},
+      {0x0B, {"Record Off", &Decoder::do_operand<None>}},
+      {0x0D, {"Text View On", &Decoder::do_operand<None>}},
+      {0x0F, {"Record TV Screen", &Decoder::do_operand<None>}},
+      {0x1A, {"Give Deck Status", &Decoder::do_operand<StatusRequest>}},
+      {0x1B, {"Deck Status", &Decoder::do_operand<DeckInfo>}},
+      {0x32, {"Set Menu Language", &Decoder::do_operand<Language>}},
+      {0x33, {"Clear Analogue Timer", &Decoder::do_operand<Two(StartDateTime, Duration)>}},
+      {0x34, {"Set Analogue Timer", &Decoder::do_operand<Two(StartDateTime, Duration)>}},
+      {0x35, {"Timer Status", &Decoder::do_operand<TimerStatusData>}},
+      {0x36, {"Standby", &Decoder::do_operand<None>}},
+      {0x41, {"Play", &Decoder::do_operand<PlayMode>}},
+      {0x42, {"Deck Control", &Decoder::do_operand<DeckControlMode>}},
+      {0x43, {"Timer Cleared Status", &Decoder::do_operand<TimerClearedStatusData>}},
+      {0x44, {"User Control Pressed", &Decoder::do_operand<UICommand>}},
+      {0x45, {"User Control Released", &Decoder::do_operand<None>}},
+      {0x46, {"Give OSD Name", &Decoder::do_operand<None>}},
+      {0x47, {"Set OSD Name", &Decoder::do_operand<OsdName>}},
+      {0x64, {"Set OSD String", &Decoder::do_operand<Two(DisplayControl, OsdString)>}},
+      {0x67, {"Set Timer Program Title", &Decoder::do_operand<ProgramTitleString>}},
+      {0x70, {"System Audio Mode Request", &Decoder::do_operand<PhysicalAddress>}},
+      {0x71, {"Give Audio Status", &Decoder::do_operand<None>}},
+      {0x72, {"Set System Audio Mode", &Decoder::do_operand<SystemAudioStatus>}},
+      {0x7A, {"Report Audio Status", &Decoder::do_operand<AudioStatus>}},
+      {0x7D, {"Give System Audio Mode Status", &Decoder::do_operand<None>}},
+      {0x7E, {"System Audio Mode Status", &Decoder::do_operand<SystemAudioStatus>}},
+      {0x80, {"Routing Change", &Decoder::do_operand<Two(PhysicalAddress, PhysicalAddress)>}},
+      {0x81, {"Routing Information", &Decoder::do_operand<PhysicalAddress>}},
+      {0x82, {"Active Source", &Decoder::do_operand<PhysicalAddress>}},
+      {0x83, {"Give Physical Address", &Decoder::do_operand<None>}},
+      {0x84, {"Report Physical Address", &Decoder::do_operand<Two(PhysicalAddress, DeviceType)>}},
+      {0x85, {"Request Active Source", &Decoder::do_operand<None>}},
+      {0x86, {"Set Stream Path", &Decoder::do_operand<PhysicalAddress>}},
+      {0x87, {"Device Vendor ID", &Decoder::do_operand<VendorId>}},
+      {0x89, {"Vendor Command", &Decoder::do_operand<VendorSpecificData>}},
+      {0x8A, {"Vendor Remote Button Down", &Decoder::do_operand<VendorSpecificRCCode>}},
+      {0x8B, {"Vendor Remote Button Up", &Decoder::do_operand<None>}},
+      {0x8C, {"Give Device Vendor ID", &Decoder::do_operand<None>}},
+      {0x8D, {"Menu Request", &Decoder::do_operand<MenuRequestType>}},
+      {0x8E, {"Menu Status", &Decoder::do_operand<MenuState>}},
+      {0x8F, {"Give Device Power Status", &Decoder::do_operand<None>}},
+      {0x90, {"Report Power Status", &Decoder::do_operand<PowerStatus>}},
+      {0x91, {"Get Menu Language", &Decoder::do_operand<None>}},
+      {0x92,
+       {"Select Analogue Service", &Decoder::do_operand<Three(AnalogBroadcastType, AnalogFrequency, BroadcastSystem)>}},
+      {0x93, {"Select Digital Service", &Decoder::do_operand<DigitalServiceIdentification>}},
+      {0x97, {"Set Digital Timer", &Decoder::do_operand<Two(StartDateTime, Duration)>}},
+      {0x99, {"Clear Digital Timer", &Decoder::do_operand<Two(StartDateTime, Duration)>}},
+      {0x9A, {"Set Audio Rate", &Decoder::do_operand<AudioRate>}},
+      {0x9D, {"Inactive Source", &Decoder::do_operand<PhysicalAddress>}},
+      {0x9E, {"CEC Version", &Decoder::do_operand<CecVersion>}},
+      {0x9F, {"Get CEC Version", &Decoder::do_operand<None>}},
+      {0xA0, {"Vendor Command With ID", &Decoder::do_operand<Two(VendorId, VendorSpecificData)>}},
+      {0xA1, {"Clear External Timer", &Decoder::do_operand<Two(StartDateTime, Duration)>}},
+      {0xA2, {"Set External Timer", &Decoder::do_operand<Two(StartDateTime, Duration)>}},
+      {0xA3, {"Report Short Audio Descriptor", &Decoder::do_operand<ShortAudioDescriptor>}},
+      {0xA4, {"Request Short Audio Descriptor", &Decoder::do_operand<AudioFormat>}},
+      {0xC0, {"Initiate ARC", &Decoder::do_operand<None>}},
+      {0xC1, {"Report ARC Initiated", &Decoder::do_operand<None>}},
+      {0xC2, {"Report ARC Terminated", &Decoder::do_operand<None>}},
+      {0xC3, {"Request ARC Initiation", &Decoder::do_operand<None>}},
+      {0xC4, {"Request ARC Termination", &Decoder::do_operand<None>}},
+      {0xC5, {"Terminate ARC", &Decoder::do_operand<None>}},
+      {0xF8, {"CDC Message", &Decoder::do_operand<None>}},
+      {0xFF, {"Abort", &Decoder::do_operand<None>}},
+  };
+  static_assert(
+      []() constexpr {
+        for (size_t i = 1; i < sizeof(table) / sizeof(table[0]); i++)
+          if (table[i].opcode <= table[i - 1].opcode)
+            return false;
+        return true;
+      }(),
+      "opcode table must be sorted");
 
-const std::map<uint32_t, const char *> Decoder::vendor_ids = {
-    {0x000039, "Toshiba"},       {0x0000F0, "Samsung"},       {0x00044B, "NVIDIA"}, {0x0005CD, "Denon"},
-    {0x000678, "Marantz"},       {0x000982, "Loewe"},         {0x0009B0, "Onkyo"},  {0x000CB8, "Medion"},
-    {0x000CE7, "Toshiba"},       {0x000D4B, "Roku"},          {0x0010FA, "Apple"},  {0x001582, "Pulse Eight"},
-    {0x001950, "Harman Kardon"}, {0x001A11, "Google"},        {0x0020C7, "Akai"},   {0x002467, "AOC"},
-    {0x008045, "Panasonic"},     {0x00903E, "Philips"},       {0x009053, "Daewoo"}, {0x00A0DE, "Yamaha"},
-    {0x00D0D5, "Grundig"},       {0x00E036, "Pioneer"},       {0x00E091, "LG"},     {0x08001F, "Sharp"},
-    {0x080046, "Sony"},          {0x18C086, "Broadcom"},      {0x534850, "Sharp"},  {0x6B746D, "Vizio"},
-    {0x8065E9, "BenQ"},          {0x9C645E, "Harman Kardon"},
-};
+  auto *it = std::lower_bound(std::begin(table), std::end(table), opcode,
+                              [](const Entry &e, uint8_t val) { return e.opcode < val; });
+  if (it != std::end(table) && it->opcode == opcode)
+    return &it->type;
+  return nullptr;
+}
+
+const char *Decoder::find_vendor_name(uint32_t id) {
+  struct Entry {
+    uint32_t id;
+    const char *name;
+  };
+  // Sorted by vendor ID for binary search
+  static constexpr Entry table[] = {
+      {0x000039, "Toshiba"},       {0x0000F0, "Samsung"},       {0x00044B, "NVIDIA"}, {0x0005CD, "Denon"},
+      {0x000678, "Marantz"},       {0x000982, "Loewe"},         {0x0009B0, "Onkyo"},  {0x000CB8, "Medion"},
+      {0x000CE7, "Toshiba"},       {0x000D4B, "Roku"},          {0x0010FA, "Apple"},  {0x001582, "Pulse Eight"},
+      {0x001950, "Harman Kardon"}, {0x001A11, "Google"},        {0x0020C7, "Akai"},   {0x002467, "AOC"},
+      {0x008045, "Panasonic"},     {0x00903E, "Philips"},       {0x009053, "Daewoo"}, {0x00A0DE, "Yamaha"},
+      {0x00D0D5, "Grundig"},       {0x00E036, "Pioneer"},       {0x00E091, "LG"},     {0x08001F, "Sharp"},
+      {0x080046, "Sony"},          {0x18C086, "Broadcom"},      {0x534850, "Sharp"},  {0x6B746D, "Vizio"},
+      {0x8065E9, "BenQ"},          {0x9C645E, "Harman Kardon"},
+  };
+  static_assert(
+      []() constexpr {
+        for (size_t i = 1; i < sizeof(table) / sizeof(table[0]); i++)
+          if (table[i].id <= table[i - 1].id)
+            return false;
+        return true;
+      }(),
+      "vendor table must be sorted");
+
+  auto *it =
+      std::lower_bound(std::begin(table), std::end(table), id, [](const Entry &e, uint32_t val) { return e.id < val; });
+  if (it != std::end(table) && it->id == id)
+    return it->name;
+  return nullptr;
+}
 
 std::string Decoder::address_decode() const {
-  const static std::array<const char *, 16> names = {"TV",           "RecordingDev1", "RecordingDev2", "Tuner1",
-                                                     "PlaybackDev1", "AudioSystem",   "Tuner2",        "Tuner3",
-                                                     "PlaybackDev2", "RecordingDev3", "Tuner4",        "PlaybackDev3",
-                                                     "Reserved",     "Reserved",      "SpecificUse",   "Unregistered"};
+  const static std::array<const char *, 16> names = {
+      "TV",             // 0x0
+      "RecordingDev1",  // 0x1
+      "RecordingDev2",  // 0x2
+      "Tuner1",         // 0x3
+      "PlaybackDev1",   // 0x4
+      "AudioSystem",    // 0x5
+      "Tuner2",         // 0x6
+      "Tuner3",         // 0x7
+      "PlaybackDev2",   // 0x8
+      "RecordingDev3",  // 0x9
+      "Tuner4",         // 0xA
+      "PlaybackDev3",   // 0xB
+      "Reserved",       // 0xC
+      "Reserved",       // 0xD
+      "SpecificUse",    // 0xE
+      "Unregistered",   // 0xF
+  };
   const char *dest = (frame_.is_broadcast()) ? "All" : names[frame_.destination_addr()];
   return std::string(names[frame_.initiator_addr()]) + " to " + dest + ": ";
 }
 
 const char *Decoder::find_opcode_name(uint32_t opcode) const {
-  auto it = cec_opcode_table.find(opcode);
-  if (it == cec_opcode_table.end()) {
-    return "?";
-  }
-  return it->second.name;
+  auto *entry = find_opcode(opcode);
+  return entry ? entry->name : "?";
 }
 
 /**
@@ -441,17 +563,17 @@ std::string Decoder::decode() {
     return result + "Ping";
   }
 
-  auto it = cec_opcode_table.find(frame_.opcode());
-  if (it == cec_opcode_table.end()) {
+  auto *entry = find_opcode(frame_.opcode());
+  if (entry == nullptr) {
     return result + std::string("<?>");
   }
 
-  result += std::string("<") + it->second.name + ">";
+  result += std::string("<") + entry->name + ">";
   // operand fields
   length_ = 0;         // currently accumulated length of text of operands
   line_[length_] = 0;  // initialise operand text to empty string
   offset_ = 2;         // location in frame of first operand to decode
-  OperandDecode_f f = it->second.decode_f;
+  OperandDecode_f f = entry->decode_f;
   (this->*f)();
   result += &line_[0];
   return result;

--- a/components/hdmi_cec/cec_decoder.cpp
+++ b/components/hdmi_cec/cec_decoder.cpp
@@ -391,13 +391,15 @@ const Decoder::CecOpcodeTable Decoder::cec_opcode_table = {
     {0xF8, {"CDC Message", &Decoder::do_operand<None>}}};
 
 const std::map<uint32_t, const char *> Decoder::vendor_ids = {
-    {0x000039, "Toshiba"}, {0x0000F0, "Samsung"},     {0x0005CD, "Denon"},         {0x000678, "Marantz"},
-    {0x000982, "Loewe"},   {0x0009B0, "Onkyo"},       {0x000CB8, "Medion"},        {0x000CE7, "Toshiba"},
-    {0x0010FA, "Apple"},   {0x001582, "Pulse Eight"}, {0x001950, "Harman Kardon"}, {0x001A11, "Google"},
-    {0x0020C7, "Akai"},    {0x002467, "AOC"},         {0x008045, "Panasonic"},     {0x00903E, "Philips"},
-    {0x009053, "Daewoo"},  {0x00A0DE, "Yamaha"},      {0x00D0D5, "Grundig"},       {0x00E036, "Pioneer"},
-    {0x00E091, "LG"},      {0x08001F, "Sharp"},       {0x080046, "Sony"},          {0x18C086, "Broadcom"},
-    {0x534850, "Sharp"},   {0x6B746D, "Vizio"},       {0x8065E9, "BenQ"},          {0x9C645E, "Harman Kardon"}};
+    {0x000039, "Toshiba"},       {0x0000F0, "Samsung"},       {0x00044B, "NVIDIA"}, {0x0005CD, "Denon"},
+    {0x000678, "Marantz"},       {0x000982, "Loewe"},         {0x0009B0, "Onkyo"},  {0x000CB8, "Medion"},
+    {0x000CE7, "Toshiba"},       {0x000D4B, "Roku"},          {0x0010FA, "Apple"},  {0x001582, "Pulse Eight"},
+    {0x001950, "Harman Kardon"}, {0x001A11, "Google"},        {0x0020C7, "Akai"},   {0x002467, "AOC"},
+    {0x008045, "Panasonic"},     {0x00903E, "Philips"},       {0x009053, "Daewoo"}, {0x00A0DE, "Yamaha"},
+    {0x00D0D5, "Grundig"},       {0x00E036, "Pioneer"},       {0x00E091, "LG"},     {0x08001F, "Sharp"},
+    {0x080046, "Sony"},          {0x18C086, "Broadcom"},      {0x534850, "Sharp"},  {0x6B746D, "Vizio"},
+    {0x8065E9, "BenQ"},          {0x9C645E, "Harman Kardon"},
+};
 
 std::string Decoder::address_decode() const {
   const static std::array<const char *, 16> names = {"TV",           "RecordingDev1", "RecordingDev2", "Tuner1",

--- a/components/hdmi_cec/cec_decoder.h
+++ b/components/hdmi_cec/cec_decoder.h
@@ -4,7 +4,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <map>
 
 #include "hdmi_cec.h"
 
@@ -24,6 +23,10 @@ class Decoder {
  public:
   Decoder(const Frame &frame) : frame_(frame), length_(0), offset_(2) {}
   std::string decode();
+  static const char *find_vendor_name(uint32_t id);
+  static const char *find_device_type_name(uint8_t type);
+  static const char *find_power_status_name(uint8_t status);
+  static const char *find_cec_version_name(uint8_t version);
 
  protected:
   const char *find_opcode_name(uint32_t opcode) const;
@@ -44,8 +47,7 @@ class Decoder {
     const char *name;                // name of the operation (of the op_code)
     const OperandDecode_f decode_f;  // a pointer to the corresponding 'do_operand()' method
   };
-  using CecOpcodeTable = const std::map<uint8_t, FrameType>;
-  const static CecOpcodeTable cec_opcode_table;
+  static const FrameType *find_opcode(uint8_t opcode);
 
   const Frame &frame_;
   std::array<char, 256> line_;  // to hold the text of the decoded frame
@@ -138,13 +140,6 @@ class Decoder {
     return append_operand(s);
   }
 
-  /**
-   * String tables used in the subsequent 'do_operand' decode functions
-   */
-  const static std::array<const char *, 0x77> UI_Commands;
-  const static std::array<const char *, 0x11> audio_formats;
-  const static std::array<const char *, 8> audio_samplerates;
-  const static std::map<uint32_t, const char *> vendor_ids;
 };  // class Decoder
 }  // namespace hdmi_cec
 }  // namespace esphome

--- a/components/hdmi_cec/cec_decoder.h
+++ b/components/hdmi_cec/cec_decoder.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <map>
-#include <array>
 
 #include "hdmi_cec.h"
 

--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -1,4 +1,5 @@
 #include "hdmi_cec.h"
+
 #include "esphome/core/log.h"
 
 #ifdef USE_CEC_DECODER
@@ -55,9 +56,7 @@ std::string Frame::to_string(bool skip_decode) const {
   return result;
 }
 
-inline void IRAM_ATTR HDMICEC::set_pin_input_high() {
-  pin_->pin_mode(INPUT_MODE_FLAGS);
-}
+inline void IRAM_ATTR HDMICEC::set_pin_input_high() { pin_->pin_mode(INPUT_MODE_FLAGS); }
 
 inline void IRAM_ATTR HDMICEC::set_pin_output_low() {
   pin_->pin_mode(OUTPUT_MODE_FLAGS);
@@ -65,7 +64,7 @@ inline void IRAM_ATTR HDMICEC::set_pin_output_low() {
 }
 
 void HDMICEC::setup() {
-  this->pin_->setup();  
+  this->pin_->setup();
   isr_pin_ = pin_->to_isr();
   frames_queue_.reset();
   pin_->attach_interrupt(HDMICEC::gpio_intr_, this, gpio::INTERRUPT_ANY_EDGE);
@@ -110,14 +109,12 @@ void HDMICEC::loop() {
     bool handled_by_trigger = false;
     uint8_t opcode = data[0];
     for (auto trigger : message_triggers_) {
-      bool can_trigger = (
-        (!trigger->source_.has_value()      || (trigger->source_ == src_addr)) &&
-        (!trigger->destination_.has_value() || (trigger->destination_ == dest_addr)) &&
-        (!trigger->opcode_.has_value()      || (trigger->opcode_ == opcode)) &&
-        (!trigger->data_.has_value() ||
-          (data.size() == trigger->data_->size() && std::equal(trigger->data_->begin(), trigger->data_->end(), data.begin()))
-        )
-      );
+      bool can_trigger =
+          ((!trigger->source_.has_value() || (trigger->source_ == src_addr)) &&
+           (!trigger->destination_.has_value() || (trigger->destination_ == dest_addr)) &&
+           (!trigger->opcode_.has_value() || (trigger->opcode_ == opcode)) &&
+           (!trigger->data_.has_value() || (data.size() == trigger->data_->size() &&
+                                            std::equal(trigger->data_->begin(), trigger->data_->end(), data.begin()))));
       if (can_trigger) {
         trigger->trigger(src_addr, dest_addr, data);
         handled_by_trigger = true;
@@ -136,11 +133,11 @@ uint8_t logical_address_to_device_type(uint8_t logical_address) {
   switch (logical_address) {
     // "TV"
     case 0x0:
-      return 0x00; // "TV"
+      return 0x00;  // "TV"
 
     // "Audio System"
     case 0x5:
-      return 0x05; // "Audio System"
+      return 0x05;  // "Audio System"
 
     // "Recording 1"
     case 0x1:
@@ -148,7 +145,7 @@ uint8_t logical_address_to_device_type(uint8_t logical_address) {
     case 0x2:
     // "Recording 3"
     case 0x9:
-      return 0x01; // "Recording Device"
+      return 0x01;  // "Recording Device"
 
     // "Tuner 1"
     case 0x3:
@@ -158,10 +155,10 @@ uint8_t logical_address_to_device_type(uint8_t logical_address) {
     case 0x7:
     // "Tuner 4"
     case 0xA:
-      return 0x03; // "Tuner"
+      return 0x03;  // "Tuner"
 
     default:
-      return 0x04; // "Playback Device"
+      return 0x04;  // "Playback Device"
   }
 }
 
@@ -182,14 +179,14 @@ void HDMICEC::try_builtin_handler_(uint8_t source, uint8_t destination, const st
     // "Give Device Power Status" request
     case 0x8F: {
       // reply with "Report Power Status" (0x90)
-      send(address_, source, {0x90, 0x00}); // "On"
+      send(address_, source, {0x90, 0x00});  // "On"
       break;
     }
 
     // "Give OSD Name" request
     case 0x46: {
       // reply with "Set OSD Name" (0x47)
-      std::vector<uint8_t> data = { 0x47 };
+      std::vector<uint8_t> data = {0x47};
       data.insert(data.end(), osd_name_bytes_.begin(), osd_name_bytes_.end());
       send(address_, source, data);
       break;
@@ -199,7 +196,7 @@ void HDMICEC::try_builtin_handler_(uint8_t source, uint8_t destination, const st
     case 0x83: {
       // reply with "Report Physical Address" (0x84)
       auto physical_address_bytes = decode_value(physical_address_);
-      std::vector<uint8_t> data = { 0x84 };
+      std::vector<uint8_t> data = {0x84};
       data.insert(data.end(), physical_address_bytes.begin(), physical_address_bytes.end());
       // Device Type
       data.push_back(logical_address_to_device_type(address_));
@@ -221,7 +218,8 @@ void HDMICEC::try_builtin_handler_(uint8_t source, uint8_t destination, const st
 }
 
 bool HDMICEC::send(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data_bytes) {
-  if (monitor_mode_) return false;
+  if (monitor_mode_)
+    return false;
 
   bool is_broadcast = (destination == 0xF);
 
@@ -239,10 +237,12 @@ bool HDMICEC::send(uint8_t source, uint8_t destination, const std::vector<uint8_
 
     for (size_t i = 0; i < MAX_ATTEMPTS; i++) {
       int32_t delay = 0;
-      while ((delay = free_bit_periods * TOTAL_BIT_US + std::max(last_sent_us_, last_falling_edge_us_) - micros()) > 0) {
+      while ((delay = free_bit_periods * TOTAL_BIT_US + std::max(last_sent_us_, last_falling_edge_us_) - micros()) >
+             0) {
         ESP_LOGV(TAG, "HDMICEC::send(): waiting %d usec for bus free period", delay);
         delay_microseconds_safe(delay);
-        // Note: during this delay, the 'last_falling_edge_us_' might be incremented by 'gpio_intr_', requiring further wait
+        // Note: during this delay, the 'last_falling_edge_us_' might be incremented by 'gpio_intr_', requiring further
+        // wait
         free_bit_periods = 5;
       }
       ESP_LOGV(TAG, "HDMICEC::send(): bus available, sending frame...");
@@ -410,14 +410,14 @@ void IRAM_ATTR HDMICEC::gpio_intr_(HDMICEC *self) {
   }
 
   bool value = (pulse_duration >= HIGH_BIT_MIN_US && pulse_duration <= HIGH_BIT_MAX_US);
-  
+
   switch (self->receiver_state_) {
     case ReceiverState::ReceivingByte: {
       // write bit to the current byte
       self->recv_byte_buffer_ = (self->recv_byte_buffer_ << 1) | (value & 0b1);
 
       self->recv_bit_counter_++;
-      if (self->recv_bit_counter_ >= 8) { 
+      if (self->recv_bit_counter_ >= 8) {
         // if we reached eight bits, push the current byte to the frame buffer
         if (self->frame_receive_) {
           self->frame_receive_->push_back(self->recv_byte_buffer_);
@@ -450,11 +450,7 @@ void IRAM_ATTR HDMICEC::gpio_intr_(HDMICEC *self) {
         reset_state_variables_(self);
       }
 
-      self->receiver_state_ = (
-        isEOM
-        ? ReceiverState::WaitingForEOMAck
-        : ReceiverState::WaitingForAck
-      );
+      self->receiver_state_ = (isEOM ? ReceiverState::WaitingForEOMAck : ReceiverState::WaitingForAck);
       break;
     }
 
@@ -479,5 +475,5 @@ void IRAM_ATTR HDMICEC::reset_state_variables_(HDMICEC *self) {
   self->recv_byte_buffer_ = 0x0;
 }
 
-}
-}
+}  // namespace hdmi_cec
+}  // namespace esphome

--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -116,10 +116,18 @@ void HDMICEC::setup() {
   register_service(&HDMICEC::on_send_to_vendor_and_type_, "send_to_vendor_and_type",
                    {"vendor_id", "device_type", "data"});
   register_service(&HDMICEC::on_scan_bus_, "scan_bus");
+  for (auto *dev : remote_devices_) {
+    dev->register_api_service_();
+  }
 #elif defined(USE_API)
 #warning \
     "hdmi_cec: HA services (send, scan_bus, etc.) are disabled. Add 'custom_services: true' to your 'api:' config to enable them."
 #endif
+
+  set_power_poll_interval(power_poll_interval_ms_);
+  if (power_poll_number_ != nullptr) {
+    power_poll_number_->publish_state(power_poll_interval_ms_);
+  }
 }
 
 void HDMICEC::dump_config() {
@@ -351,9 +359,32 @@ void HDMICEC::complete_scan_() {
              dev.osd_name.empty() ? "" : (dev.osd_name + "\"").c_str());
   }
   ESP_LOGI(TAG, "=== %d device(s) found ===", count);
+  for (uint8_t i = 0; i <= CEC_ADDR_MAX_ASSIGNABLE; i++) {
+    notify_remote_devices_(i);
+  }
   for (auto *trigger : scan_complete_triggers_) {
     trigger->trigger();
   }
+}
+
+void HDMICEC::set_power_poll_interval(uint32_t ms) {
+  power_poll_interval_ms_ = ms;
+  cancel_interval("poll_power");
+  if (ms == 0)
+    return;
+  set_interval("poll_power", ms, [this]() {
+    if (remote_devices_.empty())
+      return;
+    for (size_t i = 0; i < remote_devices_.size(); i++) {
+      poll_power_index_ = (poll_power_index_ + 1) % remote_devices_.size();
+      auto *dev = remote_devices_[poll_power_index_];
+      auto addr = dev->get_address();
+      if (addr.has_value() && dev->needs_power_poll()) {
+        send(address_, *addr, {CEC_OPCODE_GIVE_DEVICE_POWER_STATUS});
+        break;
+      }
+    }
+  });
 }
 
 void HDMICEC::update_devices_(uint8_t src, uint8_t dest, const std::vector<uint8_t> &data) {
@@ -415,6 +446,8 @@ void HDMICEC::update_devices_(uint8_t src, uint8_t dest, const std::vector<uint8
     default:
       return;
   }
+
+  notify_remote_devices_(src);
 
   // During a scan, chain the next query based on the response we just got.
   // Feature Abort contains the rejected request opcode in data[1], so we can
@@ -862,6 +895,108 @@ std::string CECDevice::power_status_to_string(uint8_t status) {
   return "Unknown";
 }
 
+// --- HDMICEC device methods ---
+
+void HDMICEC::send_button_press(uint8_t destination, uint8_t ui_command) {
+  send(address_, destination, {CEC_OPCODE_USER_CONTROL_PRESSED, ui_command});
+  send(address_, destination, {CEC_OPCODE_USER_CONTROL_RELEASED});
+}
+
+void HDMICEC::notify_remote_devices_(uint8_t logical_address) {
+  if (logical_address > CEC_ADDR_MAX_ASSIGNABLE)
+    return;
+  auto &dev = devices_[logical_address];
+  for (auto *remote : remote_devices_) {
+    if (remote->matches(dev)) {
+      remote->on_device_update(dev);
+    }
+  }
+}
+
+// --- CECRemoteDevice ---
+
+bool CECRemoteDevice::matches(const CECDevice &dev) const {
+  if (dev.last_seen_ms == 0)
+    return false;
+  if (match_osd_name_.has_value() && dev.osd_name != *match_osd_name_)
+    return false;
+  if (match_physical_address_.has_value() && dev.physical_address != *match_physical_address_)
+    return false;
+  if (match_vendor_id_.has_value() && dev.vendor_id != *match_vendor_id_)
+    return false;
+  if (match_device_type_.has_value() && dev.device_type != *match_device_type_)
+    return false;
+  return true;
+}
+
+void CECRemoteDevice::on_device_update(const CECDevice &dev) {
+  resolved_address_ = dev.logical_address;
+  if (osd_name_sensor_ != nullptr)
+    osd_name_sensor_->publish_state(dev.osd_name);
+  if (device_type_sensor_ != nullptr)
+    device_type_sensor_->publish_state(CECDevice::device_type_to_string(dev.device_type));
+  if (vendor_id_sensor_ != nullptr)
+    vendor_id_sensor_->publish_state(CECDevice::vendor_id_to_string(dev.vendor_id));
+  if (vendor_name_sensor_ != nullptr)
+    vendor_name_sensor_->publish_state(CECDevice::vendor_name_to_string(dev.vendor_id));
+  if (physical_address_sensor_ != nullptr)
+    physical_address_sensor_->publish_state(CECDevice::physical_address_to_string(dev.physical_address));
+  if (power_status_sensor_ != nullptr)
+    power_status_sensor_->publish_state(CECDevice::power_status_to_string(dev.power_status));
+  if (cec_version_sensor_ != nullptr)
+    cec_version_sensor_->publish_state(CECDevice::cec_version_to_string(dev.cec_version));
+  if (active_source_sensor_ != nullptr)
+    active_source_sensor_->publish_state(dev.active_source);
+  if (last_seen_sensor_ != nullptr) {
+    uint32_t seconds_ago = (millis() - dev.last_seen_ms) / 1000;
+    if (seconds_ago < 60) {
+      last_seen_sensor_->publish_state("just now");
+    } else if (seconds_ago < 3600) {
+      char buf[16];
+      snprintf(buf, sizeof(buf), "%um ago", (unsigned) (seconds_ago / 60));
+      last_seen_sensor_->publish_state(buf);
+    } else {
+      char buf[16];
+      snprintf(buf, sizeof(buf), "%uh ago", (unsigned) (seconds_ago / 3600));
+      last_seen_sensor_->publish_state(buf);
+    }
+  }
+  if (power_switch_ != nullptr && dev.power_status != 0xFF) {
+    bool is_on = (dev.power_status == CEC_POWER_STATUS_ON || dev.power_status == CEC_POWER_STATUS_IN_TRANSITION_TO_ON);
+    power_switch_->publish_state(is_on);
+  }
+}
+
+// --- CECControlButton ---
+
+void CECControlButton::press_action() {
+  auto addr = device_->get_address();
+  if (addr.has_value()) {
+    parent_->send_button_press(*addr, ui_command_);
+  } else {
+    ESP_LOGW("hdmi_cec", "Control button: device '%s' not found on bus", device_->get_name());
+  }
+}
+
+// --- CECPowerSwitch ---
+
+void CECPowerSwitch::write_state(bool state) {
+  auto addr = device_->get_address();
+  if (addr.has_value()) {
+    parent_->send_button_press(*addr, state ? CEC_UI_COMMAND_POWER_ON : CEC_UI_COMMAND_POWER_OFF);
+  } else {
+    ESP_LOGW("hdmi_cec", "Power switch: device '%s' not found on bus", device_->get_name());
+  }
+}
+
+void CECPowerPollNumber::setup() {
+  float value;
+  pref_ = global_preferences->make_preference<float>(get_object_id_hash());
+  if (pref_.load(&value)) {
+    control(value);
+  }
+}
+
 #ifdef USE_API_CUSTOM_SERVICES
 static std::vector<uint8_t> ints_to_bytes(const std::vector<int32_t> &data) {
   return std::vector<uint8_t>(data.begin(), data.end());
@@ -885,6 +1020,19 @@ void HDMICEC::on_send_to_vendor_and_type_(int32_t vendor_id, int32_t device_type
 }
 
 void HDMICEC::on_scan_bus_() { start_scan(); }
+
+void CECRemoteDevice::register_api_service_() {
+  register_service(&CECRemoteDevice::on_api_send_, std::string("send_to_device_") + yaml_id_, {"data"});
+}
+
+void CECRemoteDevice::on_api_send_(std::vector<int32_t> data) {
+  auto addr = get_address();
+  if (addr.has_value()) {
+    parent_->send(parent_->address(), *addr, ints_to_bytes(data));
+  } else {
+    ESP_LOGW(TAG, "send_to_device: device '%s' not found on bus", name_);
+  }
+}
 #endif
 
 }  // namespace hdmi_cec

--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -85,7 +85,7 @@ void HDMICEC::loop() {
     uint8_t src_addr = ((header & 0xF0) >> 4);
     uint8_t dest_addr = (header & 0x0F);
 
-    if (!promiscuous_mode_ && (dest_addr != 0x0F) && (dest_addr != address_)) {
+    if (!promiscuous_mode_ && (dest_addr != CEC_ADDR_BROADCAST) && (dest_addr != address_)) {
       // ignore frames not meant for us, recycle frame buffer
       frames_queue_.push_front();
       continue;
@@ -122,7 +122,7 @@ void HDMICEC::loop() {
     }
 
     // If nothing in on_message handled this message, we try to run the built-in handlers
-    bool is_directly_addressed = (dest_addr != 0xF && dest_addr == address_);
+    bool is_directly_addressed = (dest_addr != CEC_ADDR_BROADCAST && dest_addr == address_);
     if (is_directly_addressed && !handled_by_trigger) {
       try_builtin_handler_(src_addr, dest_addr, data);
     }
@@ -131,34 +131,25 @@ void HDMICEC::loop() {
 
 uint8_t logical_address_to_device_type(uint8_t logical_address) {
   switch (logical_address) {
-    // "TV"
-    case 0x0:
-      return 0x00;  // "TV"
-
-    // "Audio System"
-    case 0x5:
-      return 0x05;  // "Audio System"
-
-    // "Recording 1"
-    case 0x1:
-    // "Recording 2"
-    case 0x2:
-    // "Recording 3"
-    case 0x9:
-      return 0x01;  // "Recording Device"
-
-    // "Tuner 1"
-    case 0x3:
-    // "Tuner 2"
-    case 0x6:
-    // "Tuner 3"
-    case 0x7:
-    // "Tuner 4"
-    case 0xA:
-      return 0x03;  // "Tuner"
-
+    case CEC_ADDR_TV:
+      return CEC_DEVICE_TYPE_TV;
+    case CEC_ADDR_AUDIO_SYSTEM:
+      return CEC_DEVICE_TYPE_AUDIO_SYSTEM;
+    case CEC_ADDR_RECORDING_1:
+    case CEC_ADDR_RECORDING_2:
+    case CEC_ADDR_RECORDING_3:
+      return CEC_DEVICE_TYPE_RECORDING;
+    case CEC_ADDR_TUNER_1:
+    case CEC_ADDR_TUNER_2:
+    case CEC_ADDR_TUNER_3:
+    case CEC_ADDR_TUNER_4:
+      return CEC_DEVICE_TYPE_TUNER;
+    case CEC_ADDR_PLAYBACK_1:
+    case CEC_ADDR_PLAYBACK_2:
+    case CEC_ADDR_PLAYBACK_3:
+      return CEC_DEVICE_TYPE_PLAYBACK;
     default:
-      return 0x04;  // "Playback Device"
+      return CEC_DEVICE_TYPE_OTHER;
   }
 }
 
@@ -169,50 +160,37 @@ void HDMICEC::try_builtin_handler_(uint8_t source, uint8_t destination, const st
 
   uint8_t opcode = data[0];
   switch (opcode) {
-    // "Get CEC Version" request
-    case 0x9F: {
-      // reply with "CEC Version" (0x9E)
-      send(address_, source, {0x9E, 0x04});
+    case CEC_OPCODE_GET_CEC_VERSION: {
+      send(address_, source, {CEC_OPCODE_CEC_VERSION, CEC_VERSION_1_3A});
       break;
     }
 
-    // "Give Device Power Status" request
-    case 0x8F: {
-      // reply with "Report Power Status" (0x90)
-      send(address_, source, {0x90, 0x00});  // "On"
+    case CEC_OPCODE_GIVE_DEVICE_POWER_STATUS: {
+      send(address_, source, {CEC_OPCODE_REPORT_POWER_STATUS, CEC_POWER_STATUS_ON});
       break;
     }
 
-    // "Give OSD Name" request
-    case 0x46: {
-      // reply with "Set OSD Name" (0x47)
-      std::vector<uint8_t> data = {0x47};
+    case CEC_OPCODE_GIVE_OSD_NAME: {
+      std::vector<uint8_t> data = {CEC_OPCODE_SET_OSD_NAME};
       data.insert(data.end(), osd_name_bytes_.begin(), osd_name_bytes_.end());
       send(address_, source, data);
       break;
     }
 
-    // "Give Physical Address" request
-    case 0x83: {
-      // reply with "Report Physical Address" (0x84)
+    case CEC_OPCODE_GIVE_PHYSICAL_ADDRESS: {
       auto physical_address_bytes = decode_value(physical_address_);
-      std::vector<uint8_t> data = {0x84};
+      std::vector<uint8_t> data = {CEC_OPCODE_REPORT_PHYSICAL_ADDRESS};
       data.insert(data.end(), physical_address_bytes.begin(), physical_address_bytes.end());
-      // Device Type
       data.push_back(logical_address_to_device_type(address_));
-      // Broadcast Physical Address
-      send(address_, 0xF, data);
+      send(address_, CEC_ADDR_BROADCAST, data);
       break;
     }
 
-    // Ignore "Feature Abort" opcode responses
-    case 0x00:
-      // no-op
+    case CEC_OPCODE_FEATURE_ABORT:
       break;
 
-    // default case (no built-in handler + no on_message handler) => message not supported => send "Feature Abort"
     default:
-      send(address_, source, {0x00, opcode, 0x00});
+      send(address_, source, {CEC_OPCODE_FEATURE_ABORT, opcode, CEC_ABORT_UNRECOGNIZED_OPCODE});
       break;
   }
 }
@@ -221,7 +199,7 @@ bool HDMICEC::send(uint8_t source, uint8_t destination, const std::vector<uint8_
   if (monitor_mode_)
     return false;
 
-  bool is_broadcast = (destination == 0xF);
+  bool is_broadcast = (destination == CEC_ADDR_BROADCAST);
 
   // prepare the bytes to send
   Frame frame(source, destination, data_bytes);
@@ -435,8 +413,8 @@ void IRAM_ATTR HDMICEC::gpio_intr_(HDMICEC *self) {
 
     case ReceiverState::WaitingForEOM: {
       // check if we need to acknowledge this byte on the next bit
-      uint8_t destination_address = self->frame_receive_ ? (self->frame_receive_->front() & 0x0F) : 0xF;
-      if (destination_address != 0xF && destination_address == self->address_) {
+      uint8_t destination_address = self->frame_receive_ ? (self->frame_receive_->front() & 0x0F) : CEC_ADDR_BROADCAST;
+      if (destination_address != CEC_ADDR_BROADCAST && destination_address == self->address_) {
         self->recv_ack_queued_ = true;
       }
 

--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -69,6 +69,12 @@ void HDMICEC::setup() {
   frames_queue_.reset();
   pin_->attach_interrupt(HDMICEC::gpio_intr_, this, gpio::INTERRUPT_ANY_EDGE);
   set_pin_input_high();
+
+#ifdef USE_API_CUSTOM_SERVICES
+  register_service(&HDMICEC::on_send_, "send", {"destination", "data"});
+#elif defined(USE_API)
+#warning "hdmi_cec: HA services are disabled. Add 'custom_services: true' to your 'api:' config to enable them."
+#endif
 }
 
 void HDMICEC::dump_config() {
@@ -452,6 +458,16 @@ void IRAM_ATTR HDMICEC::reset_state_variables_(HDMICEC *self) {
   self->recv_bit_counter_ = 0;
   self->recv_byte_buffer_ = 0x0;
 }
+
+#ifdef USE_API_CUSTOM_SERVICES
+static std::vector<uint8_t> ints_to_bytes(const std::vector<int32_t> &data) {
+  return std::vector<uint8_t>(data.begin(), data.end());
+}
+
+void HDMICEC::on_send_(int32_t destination, std::vector<int32_t> data) {
+  send(address_, static_cast<uint8_t>(destination), ints_to_bytes(data));
+}
+#endif
 
 }  // namespace hdmi_cec
 }  // namespace esphome

--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -21,6 +21,30 @@ static const uint32_t LOW_BIT_US = 1500;
 // arbitration and retransmission
 static const size_t MAX_ATTEMPTS = 5;
 
+// Scan query chain: each entry is {request_opcode, response_opcode}.
+// During a bus scan, we send queries in this order and chain the next
+// query when we receive the expected response.
+struct ScanQuery {
+  uint8_t request;
+  uint8_t response;
+};
+static const ScanQuery SCAN_QUERIES[] = {
+    {CEC_OPCODE_GIVE_PHYSICAL_ADDRESS, CEC_OPCODE_REPORT_PHYSICAL_ADDRESS},
+    {CEC_OPCODE_GIVE_DEVICE_VENDOR_ID, CEC_OPCODE_DEVICE_VENDOR_ID},
+    {CEC_OPCODE_GET_CEC_VERSION, CEC_OPCODE_CEC_VERSION},
+    {CEC_OPCODE_GIVE_OSD_NAME, CEC_OPCODE_SET_OSD_NAME},
+    {CEC_OPCODE_GIVE_DEVICE_POWER_STATUS, CEC_OPCODE_REPORT_POWER_STATUS},
+};
+static const size_t SCAN_QUERY_COUNT = sizeof(SCAN_QUERIES) / sizeof(SCAN_QUERIES[0]);
+
+static bool is_scan_response_opcode(uint8_t opcode) {
+  for (size_t i = 0; i < SCAN_QUERY_COUNT; i++) {
+    if (opcode == SCAN_QUERIES[i].response)
+      return true;
+  }
+  return false;
+}
+
 static const gpio::Flags INPUT_MODE_FLAGS = gpio::FLAG_INPUT | gpio::FLAG_PULLUP;
 static const gpio::Flags OUTPUT_MODE_FLAGS = gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN;
 // Note: the esp8266 does NOT support 'FLAG_OUTPUT | FLAG_OPEN_DRAIN | FLAG_PULLUP' as opposed to the esp32 and rp2040.
@@ -81,10 +105,20 @@ void HDMICEC::setup() {
     address_sensor_->publish_state(buf);
   }
 
+  if (scan_on_boot_ && !monitor_mode_) {
+    set_timeout("scan_boot", scan_boot_delay_ms_, [this]() { start_scan(); });
+  }
+
 #ifdef USE_API_CUSTOM_SERVICES
   register_service(&HDMICEC::on_send_, "send", {"destination", "data"});
+  register_service(&HDMICEC::on_send_to_osd_name_, "send_to_osd_name", {"osd_name", "data"});
+  register_service(&HDMICEC::on_send_to_physical_address_, "send_to_physical_address", {"physical_address", "data"});
+  register_service(&HDMICEC::on_send_to_vendor_and_type_, "send_to_vendor_and_type",
+                   {"vendor_id", "device_type", "data"});
+  register_service(&HDMICEC::on_scan_bus_, "scan_bus");
 #elif defined(USE_API)
-#warning "hdmi_cec: HA services are disabled. Add 'custom_services: true' to your 'api:' config to enable them."
+#warning \
+    "hdmi_cec: HA services (send, scan_bus, etc.) are disabled. Add 'custom_services: true' to your 'api:' config to enable them."
 #endif
 }
 
@@ -122,6 +156,9 @@ void HDMICEC::loop() {
     // recycle received frame buffer
     frames_queue_.push_front();
 
+    // Always update device registry from known response opcodes
+    update_devices_(src_addr, dest_addr, data);
+
     // Process on_message triggers
     bool handled_by_trigger = false;
     uint8_t opcode = data[0];
@@ -142,6 +179,17 @@ void HDMICEC::loop() {
     bool is_directly_addressed = (dest_addr != CEC_ADDR_BROADCAST && dest_addr == address_);
     if (is_directly_addressed && !handled_by_trigger) {
       try_builtin_handler_(src_addr, dest_addr, data);
+    }
+  }
+
+  // Send one initial probe per loop iteration during scan
+  if (scanning_) {
+    for (uint8_t i = 0; i <= CEC_ADDR_MAX_ASSIGNABLE; i++) {
+      if (scan_pending_[i]) {
+        scan_pending_[i] = false;
+        send(address_, i, {SCAN_QUERIES[0].request});
+        break;
+      }
     }
   }
 }
@@ -265,6 +313,202 @@ void HDMICEC::broadcast_physical_address_() {
   send(address_, CEC_ADDR_BROADCAST, data);
 }
 
+// --- Bus scanning ---
+
+void HDMICEC::start_scan() {
+  if (monitor_mode_) {
+    ESP_LOGW(TAG, "Cannot scan in monitor mode");
+    return;
+  }
+  cancel_timeout("scan_complete");
+  scanning_ = true;
+  last_scan_start_ms_ = millis();
+  for (uint8_t i = 0; i <= CEC_ADDR_MAX_ASSIGNABLE; i++) {
+    scan_pending_[i] = (i != address_);
+  }
+  ESP_LOGI(TAG, "Starting CEC bus scan");
+  set_timeout("scan_complete", 10000, [this]() { complete_scan_(); });
+}
+
+void HDMICEC::complete_scan_() {
+  scanning_ = false;
+  uint8_t count = 0;
+  ESP_LOGI(TAG, "=== CEC Bus Scan Results ===");
+  for (uint8_t i = 0; i <= CEC_ADDR_MAX_ASSIGNABLE; i++) {
+    if (devices_[i].last_seen_ms < last_scan_start_ms_)
+      continue;
+    count++;
+    auto &dev = devices_[i];
+    auto vendor_str = CECDevice::vendor_id_to_string(dev.vendor_id);
+    auto vendor_name = CECDevice::vendor_name_to_string(dev.vendor_id);
+    if (vendor_name != "Unknown")
+      vendor_str += " (" + vendor_name + ")";
+    ESP_LOGI(TAG, "  0x%X: %s, %s, vendor %s, CEC %s, %s%s%s", i,
+             CECDevice::device_type_to_string(dev.device_type).c_str(),
+             CECDevice::physical_address_to_string(dev.physical_address).c_str(), vendor_str.c_str(),
+             CECDevice::cec_version_to_string(dev.cec_version).c_str(),
+             CECDevice::power_status_to_string(dev.power_status).c_str(), dev.osd_name.empty() ? "" : ", OSD \"",
+             dev.osd_name.empty() ? "" : (dev.osd_name + "\"").c_str());
+  }
+  ESP_LOGI(TAG, "=== %d device(s) found ===", count);
+  for (auto *trigger : scan_complete_triggers_) {
+    trigger->trigger();
+  }
+}
+
+void HDMICEC::update_devices_(uint8_t src, uint8_t dest, const std::vector<uint8_t> &data) {
+  if (data.empty() || src > CEC_ADDR_MAX_ASSIGNABLE)
+    return;
+
+  auto &dev = devices_[src];
+  dev.logical_address = src;
+  dev.last_seen_ms = millis();
+
+  uint8_t opcode = data[0];
+  switch (opcode) {
+    case CEC_OPCODE_REPORT_PHYSICAL_ADDRESS:
+      if (data.size() >= 4) {
+        dev.physical_address = (uint16_t(data[1]) << 8) | data[2];
+        dev.device_type = data[3];
+        ESP_LOGD(TAG, "Device 0x%X: physical_address=%04X device_type=%d", src, dev.physical_address, dev.device_type);
+      }
+      break;
+    case CEC_OPCODE_SET_OSD_NAME:
+      if (data.size() >= 2) {
+        dev.osd_name = std::string(data.begin() + 1, data.end());
+        ESP_LOGD(TAG, "Device 0x%X: osd_name='%s'", src, dev.osd_name.c_str());
+      }
+      break;
+    case CEC_OPCODE_DEVICE_VENDOR_ID:
+      if (data.size() >= 4) {
+        dev.vendor_id = (uint32_t(data[1]) << 16) | (uint32_t(data[2]) << 8) | data[3];
+        ESP_LOGD(TAG, "Device 0x%X: vendor_id=%06X", src, dev.vendor_id);
+      }
+      break;
+    case CEC_OPCODE_REPORT_POWER_STATUS:
+      if (data.size() >= 2) {
+        dev.power_status = data[1];
+        ESP_LOGD(TAG, "Device 0x%X: power_status=%d", src, dev.power_status);
+      }
+      break;
+    case CEC_OPCODE_CEC_VERSION:
+      if (data.size() >= 2) {
+        dev.cec_version = data[1];
+        ESP_LOGD(TAG, "Device 0x%X: cec_version=%d", src, dev.cec_version);
+      }
+      break;
+    case CEC_OPCODE_ACTIVE_SOURCE:
+      if (data.size() >= 3) {
+        for (auto &d : devices_) d.active_source = false;
+        dev.active_source = true;
+        dev.physical_address = (uint16_t(data[1]) << 8) | data[2];
+        ESP_LOGD(TAG, "Device 0x%X: active_source, physical_address=%04X", src, dev.physical_address);
+        if (active_source_sensor_ != nullptr) {
+          char buf[5];
+          sprintf(buf, "0x%X", src);
+          active_source_sensor_->publish_state(buf);
+        }
+      }
+      break;
+    case CEC_OPCODE_FEATURE_ABORT:
+      break;
+    default:
+      return;
+  }
+
+  // During a scan, chain the next query based on the response we just got.
+  // Feature Abort contains the rejected request opcode in data[1], so we can
+  // match it against SCAN_QUERIES[i].request to skip to the next query.
+  if (scanning_) {
+    for (size_t i = 0; i + 1 < SCAN_QUERY_COUNT; i++) {
+      bool is_response = (opcode == SCAN_QUERIES[i].response);
+      bool is_abort = (opcode == CEC_OPCODE_FEATURE_ABORT && data.size() >= 2 && data[1] == SCAN_QUERIES[i].request);
+      if (is_response || is_abort) {
+        send(address_, src, {SCAN_QUERIES[i + 1].request});
+        break;
+      }
+    }
+  }
+}
+
+const CECDevice &HDMICEC::get_device(uint8_t logical_address) const {
+  static const CECDevice EMPTY{};
+  if (logical_address > CEC_ADDR_MAX_ASSIGNABLE)
+    return EMPTY;
+  return devices_[logical_address];
+}
+
+bool HDMICEC::seen_on_last_scan(uint8_t logical_address) const {
+  if (logical_address > CEC_ADDR_MAX_ASSIGNABLE || last_scan_start_ms_ == 0)
+    return false;
+  return devices_[logical_address].last_seen_ms >= last_scan_start_ms_;
+}
+
+optional<uint8_t> HDMICEC::find_address_by_osd_name(const std::string &name) const {
+  optional<uint8_t> best;
+  uint32_t best_seen = 0;
+  for (uint8_t i = 0; i <= CEC_ADDR_MAX_ASSIGNABLE; i++) {
+    if (devices_[i].last_seen_ms > 0 && devices_[i].osd_name == name && devices_[i].last_seen_ms >= best_seen) {
+      best = i;
+      best_seen = devices_[i].last_seen_ms;
+    }
+  }
+  return best;
+}
+
+optional<uint8_t> HDMICEC::find_address_by_physical_address(uint16_t addr) const {
+  optional<uint8_t> best;
+  uint32_t best_seen = 0;
+  for (uint8_t i = 0; i <= CEC_ADDR_MAX_ASSIGNABLE; i++) {
+    if (devices_[i].last_seen_ms > 0 && devices_[i].physical_address == addr && devices_[i].last_seen_ms >= best_seen) {
+      best = i;
+      best_seen = devices_[i].last_seen_ms;
+    }
+  }
+  return best;
+}
+
+optional<uint8_t> HDMICEC::find_address_by_vendor_and_type(uint32_t vendor_id, uint8_t device_type) const {
+  optional<uint8_t> best;
+  uint32_t best_seen = 0;
+  for (uint8_t i = 0; i <= CEC_ADDR_MAX_ASSIGNABLE; i++) {
+    if (devices_[i].last_seen_ms > 0 && devices_[i].vendor_id == vendor_id && devices_[i].device_type == device_type &&
+        devices_[i].last_seen_ms >= best_seen) {
+      best = i;
+      best_seen = devices_[i].last_seen_ms;
+    }
+  }
+  return best;
+}
+
+bool HDMICEC::send_to_osd_name(uint8_t source, const std::string &name, const std::vector<uint8_t> &data) {
+  auto addr = find_address_by_osd_name(name);
+  if (addr.has_value()) {
+    return send(source, *addr, data);
+  }
+  ESP_LOGW(TAG, "send_to_osd_name: no device found with name '%s'", name.c_str());
+  return false;
+}
+
+bool HDMICEC::send_to_physical_address(uint8_t source, uint16_t phys_addr, const std::vector<uint8_t> &data) {
+  auto addr = find_address_by_physical_address(phys_addr);
+  if (addr.has_value()) {
+    return send(source, *addr, data);
+  }
+  ESP_LOGW(TAG, "send_to_physical_address: no device found with address 0x%04X", phys_addr);
+  return false;
+}
+
+bool HDMICEC::send_to_vendor_and_type(uint8_t source, uint32_t vendor_id, uint8_t device_type,
+                                      const std::vector<uint8_t> &data) {
+  auto addr = find_address_by_vendor_and_type(vendor_id, device_type);
+  if (addr.has_value()) {
+    return send(source, *addr, data);
+  }
+  ESP_LOGW(TAG, "send_to_vendor_and_type: no device found with vendor 0x%06X type %d", vendor_id, device_type);
+  return false;
+}
+
 void HDMICEC::try_builtin_handler_(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data) {
   if (data.empty()) {
     return;
@@ -299,9 +543,12 @@ void HDMICEC::try_builtin_handler_(uint8_t source, uint8_t destination, const st
     }
 
     case CEC_OPCODE_FEATURE_ABORT:
+    case CEC_OPCODE_ACTIVE_SOURCE:
       break;
 
     default:
+      if (is_scan_response_opcode(opcode))
+        break;
       send(address_, source, {CEC_OPCODE_FEATURE_ABORT, opcode, CEC_ABORT_UNRECOGNIZED_OPCODE});
       break;
   }
@@ -565,6 +812,56 @@ void IRAM_ATTR HDMICEC::reset_state_variables_(HDMICEC *self) {
   self->recv_byte_buffer_ = 0x0;
 }
 
+// --- CECDevice static methods ---
+
+std::string CECDevice::device_type_to_string(uint8_t type) {
+#ifdef USE_CEC_DECODER
+  const char *name = Decoder::find_device_type_name(type);
+  if (name != nullptr)
+    return name;
+#endif
+  return "Unknown";
+}
+
+std::string CECDevice::physical_address_to_string(uint16_t addr) {
+  char buf[12];
+  snprintf(buf, sizeof(buf), "%d.%d.%d.%d", (addr >> 12) & 0xF, (addr >> 8) & 0xF, (addr >> 4) & 0xF, addr & 0xF);
+  return buf;
+}
+
+std::string CECDevice::vendor_id_to_string(uint32_t id) {
+  char buf[9];
+  snprintf(buf, sizeof(buf), "0x%06X", id);
+  return buf;
+}
+
+std::string CECDevice::vendor_name_to_string(uint32_t id) {
+#ifdef USE_CEC_DECODER
+  const char *name = Decoder::find_vendor_name(id);
+  if (name != nullptr)
+    return name;
+#endif
+  return "Unknown";
+}
+
+std::string CECDevice::cec_version_to_string(uint8_t version) {
+#ifdef USE_CEC_DECODER
+  const char *name = Decoder::find_cec_version_name(version);
+  if (name != nullptr)
+    return name;
+#endif
+  return "Unknown";
+}
+
+std::string CECDevice::power_status_to_string(uint8_t status) {
+#ifdef USE_CEC_DECODER
+  const char *name = Decoder::find_power_status_name(status);
+  if (name != nullptr)
+    return name;
+#endif
+  return "Unknown";
+}
+
 #ifdef USE_API_CUSTOM_SERVICES
 static std::vector<uint8_t> ints_to_bytes(const std::vector<int32_t> &data) {
   return std::vector<uint8_t>(data.begin(), data.end());
@@ -573,6 +870,21 @@ static std::vector<uint8_t> ints_to_bytes(const std::vector<int32_t> &data) {
 void HDMICEC::on_send_(int32_t destination, std::vector<int32_t> data) {
   send(address_, static_cast<uint8_t>(destination), ints_to_bytes(data));
 }
+
+void HDMICEC::on_send_to_osd_name_(std::string osd_name, std::vector<int32_t> data) {
+  send_to_osd_name(address_, osd_name, ints_to_bytes(data));
+}
+
+void HDMICEC::on_send_to_physical_address_(int32_t physical_address, std::vector<int32_t> data) {
+  send_to_physical_address(address_, static_cast<uint16_t>(physical_address), ints_to_bytes(data));
+}
+
+void HDMICEC::on_send_to_vendor_and_type_(int32_t vendor_id, int32_t device_type, std::vector<int32_t> data) {
+  send_to_vendor_and_type(address_, static_cast<uint32_t>(vendor_id), static_cast<uint8_t>(device_type),
+                          ints_to_bytes(data));
+}
+
+void HDMICEC::on_scan_bus_() { start_scan(); }
 #endif
 
 }  // namespace hdmi_cec

--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -70,6 +70,17 @@ void HDMICEC::setup() {
   pin_->attach_interrupt(HDMICEC::gpio_intr_, this, gpio::INTERRUPT_ANY_EDGE);
   set_pin_input_high();
 
+  if (negotiation_needed_) {
+    negotiate_address_();
+    broadcast_physical_address_();
+  }
+
+  if (address_sensor_ != nullptr) {
+    char buf[5];
+    sprintf(buf, "0x%X", address_);
+    address_sensor_->publish_state(buf);
+  }
+
 #ifdef USE_API_CUSTOM_SERVICES
   register_service(&HDMICEC::on_send_, "send", {"destination", "data"});
 #elif defined(USE_API)
@@ -80,7 +91,7 @@ void HDMICEC::setup() {
 void HDMICEC::dump_config() {
   ESP_LOGCONFIG(TAG, "HDMI-CEC");
   LOG_PIN("  pin: ", pin_);
-  ESP_LOGCONFIG(TAG, "  address: %x", address_);
+  ESP_LOGCONFIG(TAG, "  address: 0x%X", address_);
   ESP_LOGCONFIG(TAG, "  promiscuous mode: %s", (promiscuous_mode_ ? "yes" : "no"));
   ESP_LOGCONFIG(TAG, "  monitor mode: %s", (monitor_mode_ ? "yes" : "no"));
 }
@@ -157,6 +168,101 @@ uint8_t logical_address_to_device_type(uint8_t logical_address) {
     default:
       return CEC_DEVICE_TYPE_OTHER;
   }
+}
+
+static const std::vector<uint8_t> &device_type_to_candidate_addresses(uint8_t device_type) {
+  static const std::vector<uint8_t> TV_ADDRS = {CEC_ADDR_TV};
+  static const std::vector<uint8_t> RECORDING_ADDRS = {CEC_ADDR_RECORDING_1, CEC_ADDR_RECORDING_2,
+                                                       CEC_ADDR_RECORDING_3};
+  static const std::vector<uint8_t> TUNER_ADDRS = {CEC_ADDR_TUNER_1, CEC_ADDR_TUNER_2, CEC_ADDR_TUNER_3,
+                                                   CEC_ADDR_TUNER_4};
+  static const std::vector<uint8_t> PLAYBACK_ADDRS = {CEC_ADDR_PLAYBACK_1, CEC_ADDR_PLAYBACK_2, CEC_ADDR_PLAYBACK_3};
+  static const std::vector<uint8_t> AUDIO_ADDRS = {CEC_ADDR_AUDIO_SYSTEM};
+  static const std::vector<uint8_t> OTHER_ADDRS = {CEC_ADDR_FREE_USE, CEC_ADDR_RESERVED_2, CEC_ADDR_RESERVED_1};
+
+  switch (device_type) {
+    case CEC_DEVICE_TYPE_TV:
+      return TV_ADDRS;
+    case CEC_DEVICE_TYPE_RECORDING:
+      return RECORDING_ADDRS;
+    case CEC_DEVICE_TYPE_TUNER:
+      return TUNER_ADDRS;
+    case CEC_DEVICE_TYPE_PLAYBACK:
+      return PLAYBACK_ADDRS;
+    case CEC_DEVICE_TYPE_AUDIO_SYSTEM:
+      return AUDIO_ADDRS;
+    default:
+      return OTHER_ADDRS;
+  }
+}
+
+bool HDMICEC::test_address_available_(uint8_t candidate_address) {
+  // Send a polling message: header-only frame where source == destination
+  Frame frame(candidate_address, candidate_address, {});
+
+  // Wait for signal free time (5 bit periods for new initiator)
+  int32_t delay = 5 * TOTAL_BIT_US + std::max(last_sent_us_, last_falling_edge_us_) - micros();
+  if (delay > 0) {
+    delay_microseconds_safe(delay);
+  }
+
+  // For a directed message (non-broadcast), send_frame_ returns:
+  //   Success if ACKed (another device has this address)
+  //   NoAck if not ACKed (address is free)
+  auto result = send_frame_(frame, false);
+  last_sent_us_ = micros();
+
+  if (result == SendResult::NoAck) {
+    ESP_LOGD(TAG, "Address 0x%X is free", candidate_address);
+    return true;
+  }
+  ESP_LOGD(TAG, "Address 0x%X is taken (result=%d)", candidate_address, (int) result);
+  return false;
+}
+
+void HDMICEC::negotiate_address_() {
+  if (!device_type_.has_value()) {
+    return;
+  }
+
+  ESP_LOGI(TAG, "Starting CEC logical address negotiation");
+
+  address_ = CEC_ADDR_BROADCAST;  // Unregistered during negotiation
+
+  const auto &candidates = device_type_to_candidate_addresses(device_type_.value());
+
+  LockGuard send_lock(send_mutex_);
+
+  // First, try the spec-preferred addresses for our device type
+  for (uint8_t candidate : candidates) {
+    if (test_address_available_(candidate)) {
+      address_ = candidate;
+      ESP_LOGI(TAG, "Claimed logical address 0x%X", address_);
+      return;
+    }
+  }
+
+  // All preferred addresses taken. Fall back to any available address,
+  // starting from 0xE (reserved/rarely used) down through standard addresses.
+  // Skip 0xF (broadcast) and any we already tried above.
+  ESP_LOGI(TAG, "Preferred addresses taken, trying fallback addresses");
+  for (int8_t candidate = CEC_ADDR_FREE_USE; candidate >= 0; candidate--) {
+    if (test_address_available_(candidate)) {
+      address_ = candidate;
+      ESP_LOGI(TAG, "Claimed fallback logical address 0x%X", address_);
+      return;
+    }
+  }
+
+  ESP_LOGW(TAG, "All addresses taken, using Unregistered (0xF)");
+}
+
+void HDMICEC::broadcast_physical_address_() {
+  auto physical_address_bytes = decode_value(physical_address_);
+  std::vector<uint8_t> data = {CEC_OPCODE_REPORT_PHYSICAL_ADDRESS};
+  data.insert(data.end(), physical_address_bytes.begin(), physical_address_bytes.end());
+  data.push_back(logical_address_to_device_type(address_));
+  send(address_, CEC_ADDR_BROADCAST, data);
 }
 
 void HDMICEC::try_builtin_handler_(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data) {

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -8,6 +8,10 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
+#ifdef USE_API_CUSTOM_SERVICES
+#include "esphome/components/api/custom_api_device.h"
+#endif
+
 namespace esphome {
 namespace hdmi_cec {
 
@@ -156,7 +160,12 @@ template<unsigned int SIZE> class FrameRingBuffer {
 
 class MessageTrigger;
 
-class HDMICEC : public Component {
+class HDMICEC : public Component
+#ifdef USE_API_CUSTOM_SERVICES
+    ,
+                public api::CustomAPIDevice
+#endif
+{
  public:
   void set_pin(InternalGPIOPin *pin) { pin_ = pin; }
   void set_address(uint8_t address) { address_ = address; }
@@ -206,6 +215,10 @@ class HDMICEC : public Component {
   FrameRingBuffer<MAX_FRAMES_QUEUED> frames_queue_;
   bool recv_ack_queued_ = false;
   Mutex send_mutex_;
+
+#ifdef USE_API_CUSTOM_SERVICES
+  void on_send_(int32_t destination, std::vector<int32_t> data);
+#endif
 };
 
 class MessageTrigger : public Trigger<uint8_t, uint8_t, std::vector<uint8_t>> {

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <array>
-#include <vector>
 #include <atomic>
+#include <vector>
 
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
-#include "esphome/core/automation.h"
 
 namespace esphome {
 namespace hdmi_cec {
@@ -38,57 +38,61 @@ enum class SendResult : uint8_t {
 };
 
 /*
-* The FrameRingBuffer is a container for Frames to queue data in a consumer-producer
-* application. The use of std::Atomics allows safe multi-thread operation when used with
-* a single producer and single consumer thread, where each Atomic index is updated
-* by one thread only.
-* After initialization, it operates without dynamic memmory allocation.
-* This allows the gpio isr to safely and efficiently pick-up and pass Frames.
-* Due to its fixed memory size, it might return NULL pointers in case the buffer is full or empty.
-*/
-template <unsigned int SIZE>
-class FrameRingBuffer {
-  public:
-  FrameRingBuffer()
-  : front_inx_{0}
-  , back_inx_{0}
-  , store_{} {
-    for (auto& t : store_) {
+ * The FrameRingBuffer is a container for Frames to queue data in a consumer-producer
+ * application. The use of std::Atomics allows safe multi-thread operation when used with
+ * a single producer and single consumer thread, where each Atomic index is updated
+ * by one thread only.
+ * After initialization, it operates without dynamic memmory allocation.
+ * This allows the gpio isr to safely and efficiently pick-up and pass Frames.
+ * Due to its fixed memory size, it might return NULL pointers in case the buffer is full or empty.
+ */
+template<unsigned int SIZE> class FrameRingBuffer {
+ public:
+  FrameRingBuffer() : front_inx_{0}, back_inx_{0}, store_{} {
+    for (auto &t : store_) {
       t = new Frame;
       t->reserve(Frame::MAX_LENGTH);
     }
   }
   ~FrameRingBuffer() {
-    for (auto& t : store_) {
+    for (auto &t : store_) {
       delete t;
     }
   }
   // 'front' is used to access data, use that, and recycle its memory space for later use.
-  Frame* front() const { return is_empty() ? nullptr : store_[front_inx_]; }
+  Frame *front() const { return is_empty() ? nullptr : store_[front_inx_]; }
   void push_front() { cyclic_incr(front_inx_); }
   // 'back' is used to fetch a free Frame, fill with data, and queue for later pick-up
-  Frame* back() const { return is_full() ? nullptr : (store_[back_inx_]->clear(), store_[back_inx_]); }
+  Frame *back() const { return is_full() ? nullptr : (store_[back_inx_]->clear(), store_[back_inx_]); }
   void push_back() { cyclic_incr(back_inx_); }
-  bool is_empty() const {return count() == 0;}
-  bool is_full() const {return count() == SIZE;}  // using safe wrap-around of unsignd int
-  void reset() {front_inx_ = 0; back_inx_ = 0;}
+  bool is_empty() const { return count() == 0; }
+  bool is_full() const { return count() == SIZE; }  // using safe wrap-around of unsignd int
+  void reset() {
+    front_inx_ = 0;
+    back_inx_ = 0;
+  }
 
-  protected:
+ protected:
   using Index = std::atomic<unsigned int>;
   // this simple increment scheme is sufficiently 'atomic' if the front and back are each used by
   // one thread only. (So, at most one reader thread and one writer thread in the application.)
-  int count() const {int n = (int)(back_inx_ - front_inx_); if (n < 0) n += SIZE + 1; return n;}
+  int count() const {
+    int n = (int) (back_inx_ - front_inx_);
+    if (n < 0)
+      n += SIZE + 1;
+    return n;
+  }
   void cyclic_incr(Index &inx) { inx = (inx == SIZE) ? 0 : (inx + 1); }
   Index front_inx_;  // ranging 0 .. SIZE
   Index back_inx_;   // ranging 0 .. SIZE
   // if front_inx_ == back_inx_ the store is empty, so it can hold at most SIZE elements
-  std::array<Frame*, SIZE + 1> store_;
+  std::array<Frame *, SIZE + 1> store_;
 };
 
 class MessageTrigger;
 
 class HDMICEC : public Component {
-public:
+ public:
   void set_pin(InternalGPIOPin *pin) { pin_ = pin; }
   void set_address(uint8_t address) { address_ = address; }
   uint8_t address() { return address_; }
@@ -106,7 +110,7 @@ public:
   void dump_config() override;
   void loop() override;
 
-protected:
+ protected:
   static void gpio_intr_(HDMICEC *self);
   static void reset_state_variables_(HDMICEC *self);
   void try_builtin_handler_(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data);
@@ -125,11 +129,11 @@ protected:
   bool promiscuous_mode_;
   bool monitor_mode_;
   std::vector<uint8_t> osd_name_bytes_;
-  std::vector<MessageTrigger*> message_triggers_;
+  std::vector<MessageTrigger *> message_triggers_;
 
-  bool last_level_ = true;            // cec line level on last isr call
-  uint32_t last_falling_edge_us_ = 0; // timepoint in received message
-  uint32_t last_sent_us_ = 0;         // timepoint on end of sent message
+  bool last_level_ = true;             // cec line level on last isr call
+  uint32_t last_falling_edge_us_ = 0;  // timepoint in received message
+  uint32_t last_sent_us_ = 0;          // timepoint on end of sent message
   ReceiverState receiver_state_;
   uint8_t recv_bit_counter_ = 0;
   uint8_t recv_byte_buffer_ = 0;
@@ -142,14 +146,14 @@ protected:
 class MessageTrigger : public Trigger<uint8_t, uint8_t, std::vector<uint8_t>> {
   friend class HDMICEC;
 
-public:
+ public:
   explicit MessageTrigger(HDMICEC *parent) { parent->add_message_trigger(this); };
   void set_source(uint8_t source) { source_ = source; };
   void set_destination(uint8_t destination) { destination_ = destination; };
   void set_opcode(uint8_t opcode) { opcode_ = opcode; };
   void set_data(const std::vector<uint8_t> &data) { data_ = data; };
 
-protected:
+ protected:
   optional<uint8_t> source_;
   optional<uint8_t> destination_;
   optional<uint8_t> opcode_;
@@ -157,22 +161,22 @@ protected:
 };
 
 template<typename... Ts> class SendAction : public Action<Ts...> {
-public:
+ public:
   SendAction(HDMICEC *parent) : parent_(parent) {}
   TEMPLATABLE_VALUE(uint8_t, source)
   TEMPLATABLE_VALUE(uint8_t, destination)
   TEMPLATABLE_VALUE(std::vector<uint8_t>, data)
 
-  void play(const Ts&... x) override {
+  void play(const Ts &...x) override {
     auto source_address = source_.has_value() ? source_.value(x...) : parent_->address();
     auto destination_address = destination_.value(x...);
     auto data = data_.value(x...);
     parent_->send(source_address, destination_address, data);
   }
 
-protected:
+ protected:
   HDMICEC *parent_;
 };
 
-}
-}
+}  // namespace hdmi_cec
+}  // namespace esphome

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <vector>
 
+#include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
@@ -174,7 +175,12 @@ class HDMICEC : public Component
   void set_promiscuous_mode(bool promiscuous_mode) { promiscuous_mode_ = promiscuous_mode; }
   void set_monitor_mode(bool monitor_mode) { monitor_mode_ = monitor_mode; }
   void set_osd_name_bytes(const std::vector<uint8_t> &osd_name_bytes) { osd_name_bytes_ = osd_name_bytes; }
+  void set_device_type(uint8_t device_type) {
+    device_type_ = device_type;
+    negotiation_needed_ = true;
+  }
   void add_message_trigger(MessageTrigger *trigger) { message_triggers_.push_back(trigger); }
+  void set_address_sensor(text_sensor::TextSensor *sensor) { address_sensor_ = sensor; }
 
   bool send(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data_bytes);
 
@@ -188,6 +194,9 @@ class HDMICEC : public Component
   static void gpio_intr_(HDMICEC *self);
   static void reset_state_variables_(HDMICEC *self);
   void try_builtin_handler_(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data);
+  bool test_address_available_(uint8_t candidate_address);
+  void negotiate_address_();
+  void broadcast_physical_address_();
   SendResult send_frame_(const Frame &frame, bool is_broadcast);
   bool send_start_bit_();
   void send_bit_(bool bit_value);
@@ -202,8 +211,11 @@ class HDMICEC : public Component
   uint16_t physical_address_;
   bool promiscuous_mode_;
   bool monitor_mode_;
+  optional<uint8_t> device_type_;
+  bool negotiation_needed_ = false;
   std::vector<uint8_t> osd_name_bytes_;
   std::vector<MessageTrigger *> message_triggers_;
+  text_sensor::TextSensor *address_sensor_{nullptr};
 
   bool last_level_ = true;             // cec line level on last isr call
   uint32_t last_falling_edge_us_ = 0;  // timepoint in received message

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -2,8 +2,10 @@
 
 #include <array>
 #include <atomic>
+#include <string>
 #include <vector>
 
+#include "esphome/components/button/button.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
@@ -32,6 +34,7 @@ enum CecLogicalAddress : uint8_t {
   CEC_ADDR_RESERVED_1 = 0xC,
   CEC_ADDR_RESERVED_2 = 0xD,
   CEC_ADDR_FREE_USE = 0xE,
+  CEC_ADDR_MAX_ASSIGNABLE = 0xE,
   CEC_ADDR_BROADCAST = 0xF,
 };
 
@@ -39,8 +42,11 @@ enum CecOpcode : uint8_t {
   CEC_OPCODE_FEATURE_ABORT = 0x00,
   CEC_OPCODE_GIVE_OSD_NAME = 0x46,
   CEC_OPCODE_SET_OSD_NAME = 0x47,
+  CEC_OPCODE_ACTIVE_SOURCE = 0x82,
   CEC_OPCODE_GIVE_PHYSICAL_ADDRESS = 0x83,
   CEC_OPCODE_REPORT_PHYSICAL_ADDRESS = 0x84,
+  CEC_OPCODE_DEVICE_VENDOR_ID = 0x87,
+  CEC_OPCODE_GIVE_DEVICE_VENDOR_ID = 0x8C,
   CEC_OPCODE_GIVE_DEVICE_POWER_STATUS = 0x8F,
   CEC_OPCODE_REPORT_POWER_STATUS = 0x90,
   CEC_OPCODE_CEC_VERSION = 0x9E,
@@ -159,7 +165,28 @@ template<unsigned int SIZE> class FrameRingBuffer {
   std::array<Frame *, SIZE + 1> store_;
 };
 
+class CECDevice {
+ public:
+  uint8_t logical_address = 0xFF;
+  uint8_t device_type = 0xFF;
+  uint16_t physical_address = 0xFFFF;
+  std::string osd_name;
+  uint32_t vendor_id = 0xFFFFFF;
+  uint8_t power_status = 0xFF;
+  uint8_t cec_version = 0xFF;
+  bool active_source = false;
+  uint32_t last_seen_ms = 0;
+
+  static std::string device_type_to_string(uint8_t type);
+  static std::string physical_address_to_string(uint16_t addr);
+  static std::string vendor_id_to_string(uint32_t id);
+  static std::string vendor_name_to_string(uint32_t id);
+  static std::string cec_version_to_string(uint8_t version);
+  static std::string power_status_to_string(uint8_t status);
+};
+
 class MessageTrigger;
+class ScanCompleteTrigger;
 
 class HDMICEC : public Component
 #ifdef USE_API_CUSTOM_SERVICES
@@ -181,8 +208,27 @@ class HDMICEC : public Component
   }
   void add_message_trigger(MessageTrigger *trigger) { message_triggers_.push_back(trigger); }
   void set_address_sensor(text_sensor::TextSensor *sensor) { address_sensor_ = sensor; }
+  void set_active_source_sensor(text_sensor::TextSensor *sensor) { active_source_sensor_ = sensor; }
+  void add_scan_complete_trigger(ScanCompleteTrigger *trigger) { scan_complete_triggers_.push_back(trigger); }
 
   bool send(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data_bytes);
+  bool send_to_osd_name(uint8_t source, const std::string &name, const std::vector<uint8_t> &data);
+  bool send_to_physical_address(uint8_t source, uint16_t phys_addr, const std::vector<uint8_t> &data);
+  bool send_to_vendor_and_type(uint8_t source, uint32_t vendor_id, uint8_t device_type,
+                               const std::vector<uint8_t> &data);
+
+  // Bus scanning
+  void start_scan();
+  bool is_scanning() const { return scanning_; }
+  void set_scan_on_boot(bool val) { scan_on_boot_ = val; }
+  void set_scan_boot_delay(uint32_t ms) { scan_boot_delay_ms_ = ms; }
+
+  // Device registry queries
+  const CECDevice &get_device(uint8_t logical_address) const;
+  bool seen_on_last_scan(uint8_t logical_address) const;
+  optional<uint8_t> find_address_by_osd_name(const std::string &name) const;
+  optional<uint8_t> find_address_by_physical_address(uint16_t addr) const;
+  optional<uint8_t> find_address_by_vendor_and_type(uint32_t vendor_id, uint8_t device_type) const;
 
   // Component overrides
   float get_setup_priority() { return esphome::setup_priority::HARDWARE; }
@@ -197,6 +243,8 @@ class HDMICEC : public Component
   bool test_address_available_(uint8_t candidate_address);
   void negotiate_address_();
   void broadcast_physical_address_();
+  void complete_scan_();
+  void update_devices_(uint8_t src, uint8_t dest, const std::vector<uint8_t> &data);
   SendResult send_frame_(const Frame &frame, bool is_broadcast);
   bool send_start_bit_();
   void send_bit_(bool bit_value);
@@ -216,6 +264,7 @@ class HDMICEC : public Component
   std::vector<uint8_t> osd_name_bytes_;
   std::vector<MessageTrigger *> message_triggers_;
   text_sensor::TextSensor *address_sensor_{nullptr};
+  text_sensor::TextSensor *active_source_sensor_{nullptr};
 
   bool last_level_ = true;             // cec line level on last isr call
   uint32_t last_falling_edge_us_ = 0;  // timepoint in received message
@@ -228,8 +277,21 @@ class HDMICEC : public Component
   bool recv_ack_queued_ = false;
   Mutex send_mutex_;
 
+  // Device registry and scanning
+  std::array<CECDevice, CEC_ADDR_MAX_ASSIGNABLE + 1> devices_;
+  bool scanning_ = false;
+  std::array<bool, CEC_ADDR_MAX_ASSIGNABLE + 1> scan_pending_ = {};
+  uint32_t last_scan_start_ms_ = 0;
+  bool scan_on_boot_ = true;
+  uint32_t scan_boot_delay_ms_ = 3000;
+  std::vector<ScanCompleteTrigger *> scan_complete_triggers_;
+
 #ifdef USE_API_CUSTOM_SERVICES
   void on_send_(int32_t destination, std::vector<int32_t> data);
+  void on_send_to_osd_name_(std::string osd_name, std::vector<int32_t> data);
+  void on_send_to_physical_address_(int32_t physical_address, std::vector<int32_t> data);
+  void on_send_to_vendor_and_type_(int32_t vendor_id, int32_t device_type, std::vector<int32_t> data);
+  void on_scan_bus_();
 #endif
 };
 
@@ -250,6 +312,29 @@ class MessageTrigger : public Trigger<uint8_t, uint8_t, std::vector<uint8_t>> {
   optional<std::vector<uint8_t>> data_;
 };
 
+class ScanCompleteTrigger : public Trigger<> {
+ public:
+  explicit ScanCompleteTrigger(HDMICEC *parent) { parent->add_scan_complete_trigger(this); }
+};
+
+class ScanButton : public button::Button {
+ public:
+  void set_parent(HDMICEC *parent) { parent_ = parent; }
+
+ protected:
+  void press_action() override { parent_->start_scan(); }
+  HDMICEC *parent_;
+};
+
+template<typename... Ts> class ScanBusAction : public Action<Ts...> {
+ public:
+  ScanBusAction(HDMICEC *parent) : parent_(parent) {}
+  void play(const Ts &...x) override { parent_->start_scan(); }
+
+ protected:
+  HDMICEC *parent_;
+};
+
 template<typename... Ts> class SendAction : public Action<Ts...> {
  public:
   SendAction(HDMICEC *parent) : parent_(parent) {}
@@ -262,6 +347,56 @@ template<typename... Ts> class SendAction : public Action<Ts...> {
     auto destination_address = destination_.value(x...);
     auto data = data_.value(x...);
     parent_->send(source_address, destination_address, data);
+  }
+
+ protected:
+  HDMICEC *parent_;
+};
+
+template<typename... Ts> class SendToOsdNameAction : public Action<Ts...> {
+ public:
+  SendToOsdNameAction(HDMICEC *parent) : parent_(parent) {}
+  TEMPLATABLE_VALUE(uint8_t, source)
+  TEMPLATABLE_VALUE(std::string, osd_name)
+  TEMPLATABLE_VALUE(std::vector<uint8_t>, data)
+
+  void play(const Ts &...x) override {
+    auto source_address = source_.has_value() ? source_.value(x...) : parent_->address();
+    parent_->send_to_osd_name(source_address, osd_name_.value(x...), data_.value(x...));
+  }
+
+ protected:
+  HDMICEC *parent_;
+};
+
+template<typename... Ts> class SendToPhysicalAddressAction : public Action<Ts...> {
+ public:
+  SendToPhysicalAddressAction(HDMICEC *parent) : parent_(parent) {}
+  TEMPLATABLE_VALUE(uint8_t, source)
+  TEMPLATABLE_VALUE(uint16_t, physical_address)
+  TEMPLATABLE_VALUE(std::vector<uint8_t>, data)
+
+  void play(const Ts &...x) override {
+    auto source_address = source_.has_value() ? source_.value(x...) : parent_->address();
+    parent_->send_to_physical_address(source_address, physical_address_.value(x...), data_.value(x...));
+  }
+
+ protected:
+  HDMICEC *parent_;
+};
+
+template<typename... Ts> class SendToVendorAndTypeAction : public Action<Ts...> {
+ public:
+  SendToVendorAndTypeAction(HDMICEC *parent) : parent_(parent) {}
+  TEMPLATABLE_VALUE(uint8_t, source)
+  TEMPLATABLE_VALUE(uint32_t, vendor_id)
+  TEMPLATABLE_VALUE(uint8_t, device_type)
+  TEMPLATABLE_VALUE(std::vector<uint8_t>, data)
+
+  void play(const Ts &...x) override {
+    auto source_address = source_.has_value() ? source_.value(x...) : parent_->address();
+    parent_->send_to_vendor_and_type(source_address, vendor_id_.value(x...), device_type_.value(x...),
+                                     data_.value(x...));
   }
 
  protected:

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -5,7 +5,10 @@
 #include <string>
 #include <vector>
 
+#include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/button/button.h"
+#include "esphome/components/number/number.h"
+#include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
@@ -17,6 +20,8 @@
 
 namespace esphome {
 namespace hdmi_cec {
+
+static constexpr uint32_t DEFAULT_POWER_POLL_INTERVAL_MS = 2000;
 
 enum CecLogicalAddress : uint8_t {
   CEC_ADDR_TV = 0x0,
@@ -40,6 +45,10 @@ enum CecLogicalAddress : uint8_t {
 
 enum CecOpcode : uint8_t {
   CEC_OPCODE_FEATURE_ABORT = 0x00,
+  CEC_OPCODE_IMAGE_VIEW_ON = 0x04,
+  CEC_OPCODE_STANDBY = 0x36,
+  CEC_OPCODE_USER_CONTROL_PRESSED = 0x44,
+  CEC_OPCODE_USER_CONTROL_RELEASED = 0x45,
   CEC_OPCODE_GIVE_OSD_NAME = 0x46,
   CEC_OPCODE_SET_OSD_NAME = 0x47,
   CEC_OPCODE_ACTIVE_SOURCE = 0x82,
@@ -85,6 +94,11 @@ enum CecAbortReason : uint8_t {
   CEC_ABORT_CANNOT_PROVIDE_SOURCE = 0x02,
   CEC_ABORT_INVALID_OPERAND = 0x03,
   CEC_ABORT_REFUSED = 0x04,
+};
+
+enum CecUserControlCode : uint8_t {
+  CEC_UI_COMMAND_POWER_OFF = 0x6C,
+  CEC_UI_COMMAND_POWER_ON = 0x6D,
 };
 
 class Frame : public std::vector<uint8_t> {
@@ -165,6 +179,12 @@ template<unsigned int SIZE> class FrameRingBuffer {
   std::array<Frame *, SIZE + 1> store_;
 };
 
+// Forward declarations
+class HDMICEC;
+class CECRemoteDevice;
+class MessageTrigger;
+class ScanCompleteTrigger;
+
 class CECDevice {
  public:
   uint8_t logical_address = 0xFF;
@@ -184,9 +204,6 @@ class CECDevice {
   static std::string cec_version_to_string(uint8_t version);
   static std::string power_status_to_string(uint8_t status);
 };
-
-class MessageTrigger;
-class ScanCompleteTrigger;
 
 class HDMICEC : public Component
 #ifdef USE_API_CUSTOM_SERVICES
@@ -210,12 +227,16 @@ class HDMICEC : public Component
   void set_address_sensor(text_sensor::TextSensor *sensor) { address_sensor_ = sensor; }
   void set_active_source_sensor(text_sensor::TextSensor *sensor) { active_source_sensor_ = sensor; }
   void add_scan_complete_trigger(ScanCompleteTrigger *trigger) { scan_complete_triggers_.push_back(trigger); }
+  void add_remote_device(CECRemoteDevice *dev) { remote_devices_.push_back(dev); }
+  void set_power_poll_interval(uint32_t ms);
+  void set_power_poll_number(number::Number *num) { power_poll_number_ = num; }
 
   bool send(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data_bytes);
   bool send_to_osd_name(uint8_t source, const std::string &name, const std::vector<uint8_t> &data);
   bool send_to_physical_address(uint8_t source, uint16_t phys_addr, const std::vector<uint8_t> &data);
   bool send_to_vendor_and_type(uint8_t source, uint32_t vendor_id, uint8_t device_type,
                                const std::vector<uint8_t> &data);
+  void send_button_press(uint8_t destination, uint8_t ui_command);
 
   // Bus scanning
   void start_scan();
@@ -245,6 +266,7 @@ class HDMICEC : public Component
   void broadcast_physical_address_();
   void complete_scan_();
   void update_devices_(uint8_t src, uint8_t dest, const std::vector<uint8_t> &data);
+  void notify_remote_devices_(uint8_t logical_address);
   SendResult send_frame_(const Frame &frame, bool is_broadcast);
   bool send_start_bit_();
   void send_bit_(bool bit_value);
@@ -285,6 +307,7 @@ class HDMICEC : public Component
   bool scan_on_boot_ = true;
   uint32_t scan_boot_delay_ms_ = 3000;
   std::vector<ScanCompleteTrigger *> scan_complete_triggers_;
+  std::vector<CECRemoteDevice *> remote_devices_;
 
 #ifdef USE_API_CUSTOM_SERVICES
   void on_send_(int32_t destination, std::vector<int32_t> data);
@@ -293,6 +316,11 @@ class HDMICEC : public Component
   void on_send_to_vendor_and_type_(int32_t vendor_id, int32_t device_type, std::vector<int32_t> data);
   void on_scan_bus_();
 #endif
+
+  // Power status polling
+  uint32_t power_poll_interval_ms_{DEFAULT_POWER_POLL_INTERVAL_MS};
+  number::Number *power_poll_number_{nullptr};
+  size_t poll_power_index_{0};
 };
 
 class MessageTrigger : public Trigger<uint8_t, uint8_t, std::vector<uint8_t>> {
@@ -401,6 +429,130 @@ template<typename... Ts> class SendToVendorAndTypeAction : public Action<Ts...> 
 
  protected:
   HDMICEC *parent_;
+};
+
+class CECRemoteDevice
+#ifdef USE_API_CUSTOM_SERVICES
+    : public api::CustomAPIDevice
+#endif
+{
+ public:
+  void set_parent(HDMICEC *parent) { parent_ = parent; }
+  void set_name(const char *name) { name_ = name; }
+  const char *get_name() const { return name_; }
+  void set_yaml_id(const char *id) { yaml_id_ = id; }
+
+  void set_match_osd_name(const std::string &name) { match_osd_name_ = name; }
+  void set_match_physical_address(uint16_t addr) { match_physical_address_ = addr; }
+  void set_match_vendor_id(uint32_t id) { match_vendor_id_ = id; }
+  void set_match_device_type(uint8_t type) { match_device_type_ = type; }
+
+  void set_power_switch(switch_::Switch *sw) { power_switch_ = sw; }
+  void set_osd_name_sensor(text_sensor::TextSensor *s) { osd_name_sensor_ = s; }
+  void set_device_type_sensor(text_sensor::TextSensor *s) { device_type_sensor_ = s; }
+  void set_vendor_id_sensor(text_sensor::TextSensor *s) { vendor_id_sensor_ = s; }
+  void set_vendor_name_sensor(text_sensor::TextSensor *s) { vendor_name_sensor_ = s; }
+  void set_physical_address_sensor(text_sensor::TextSensor *s) { physical_address_sensor_ = s; }
+  void set_power_status_sensor(text_sensor::TextSensor *s) { power_status_sensor_ = s; }
+  void set_cec_version_sensor(text_sensor::TextSensor *s) { cec_version_sensor_ = s; }
+  void set_active_source_sensor(binary_sensor::BinarySensor *s) { active_source_sensor_ = s; }
+  void set_last_seen_sensor(text_sensor::TextSensor *s) { last_seen_sensor_ = s; }
+
+  bool matches(const CECDevice &dev) const;
+  void on_device_update(const CECDevice &dev);
+  optional<uint8_t> get_address() const { return resolved_address_; }
+  bool needs_power_poll() const { return power_switch_ != nullptr || power_status_sensor_ != nullptr; }
+
+#ifdef USE_API_CUSTOM_SERVICES
+  void register_api_service_();
+  void on_api_send_(std::vector<int32_t> data);
+#endif
+
+ protected:
+  HDMICEC *parent_{nullptr};
+  const char *name_{""};
+  const char *yaml_id_{""};
+
+  optional<std::string> match_osd_name_;
+  optional<uint16_t> match_physical_address_;
+  optional<uint32_t> match_vendor_id_;
+  optional<uint8_t> match_device_type_;
+
+  optional<uint8_t> resolved_address_;
+
+  switch_::Switch *power_switch_{nullptr};
+  text_sensor::TextSensor *osd_name_sensor_{nullptr};
+  text_sensor::TextSensor *device_type_sensor_{nullptr};
+  text_sensor::TextSensor *vendor_id_sensor_{nullptr};
+  text_sensor::TextSensor *vendor_name_sensor_{nullptr};
+  text_sensor::TextSensor *physical_address_sensor_{nullptr};
+  text_sensor::TextSensor *power_status_sensor_{nullptr};
+  text_sensor::TextSensor *cec_version_sensor_{nullptr};
+  binary_sensor::BinarySensor *active_source_sensor_{nullptr};
+  text_sensor::TextSensor *last_seen_sensor_{nullptr};
+};
+
+class CECControlButton : public button::Button {
+ public:
+  void set_parent(HDMICEC *parent) { parent_ = parent; }
+  void set_remote_device(CECRemoteDevice *dev) { device_ = dev; }
+  void set_ui_command(uint8_t cmd) { ui_command_ = cmd; }
+
+ protected:
+  void press_action() override;
+  HDMICEC *parent_{nullptr};
+  CECRemoteDevice *device_{nullptr};
+  uint8_t ui_command_{0};
+};
+
+class CECPowerSwitch : public switch_::Switch {
+ public:
+  void set_parent(HDMICEC *parent) { parent_ = parent; }
+  void set_remote_device(CECRemoteDevice *dev) { device_ = dev; }
+
+ protected:
+  void write_state(bool state) override;
+  HDMICEC *parent_{nullptr};
+  CECRemoteDevice *device_{nullptr};
+};
+
+template<typename... Ts> class SendToDeviceAction : public Action<Ts...> {
+ public:
+  SendToDeviceAction(HDMICEC *parent) : parent_(parent) {}
+  TEMPLATABLE_VALUE(uint8_t, source)
+  TEMPLATABLE_VALUE(std::vector<uint8_t>, data)
+  void set_device(CECRemoteDevice *dev) { device_ = dev; }
+
+  void play(const Ts &...x) override {
+    auto source_address = source_.has_value() ? source_.value(x...) : parent_->address();
+    auto data = data_.value(x...);
+    auto addr = device_->get_address();
+    if (addr.has_value()) {
+      parent_->send(source_address, *addr, data);
+    } else {
+      ESP_LOGW("hdmi_cec", "send_to_device: device '%s' not found on bus", device_->get_name());
+    }
+  }
+
+ protected:
+  HDMICEC *parent_;
+  CECRemoteDevice *device_{nullptr};
+};
+
+class CECPowerPollNumber : public number::Number, public Component {
+ public:
+  void set_parent(HDMICEC *parent) { parent_ = parent; }
+  float get_setup_priority() const override { return setup_priority::HARDWARE - 1.0f; }
+  void setup() override;
+
+ protected:
+  void control(float value) override {
+    publish_state(value);
+    parent_->set_power_poll_interval(static_cast<uint32_t>(value));
+    pref_.save(&value);
+  }
+  HDMICEC *parent_{nullptr};
+  ESPPreferenceObject pref_;
 };
 
 }  // namespace hdmi_cec

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -11,6 +11,71 @@
 namespace esphome {
 namespace hdmi_cec {
 
+enum CecLogicalAddress : uint8_t {
+  CEC_ADDR_TV = 0x0,
+  CEC_ADDR_RECORDING_1 = 0x1,
+  CEC_ADDR_RECORDING_2 = 0x2,
+  CEC_ADDR_TUNER_1 = 0x3,
+  CEC_ADDR_PLAYBACK_1 = 0x4,
+  CEC_ADDR_AUDIO_SYSTEM = 0x5,
+  CEC_ADDR_TUNER_2 = 0x6,
+  CEC_ADDR_TUNER_3 = 0x7,
+  CEC_ADDR_PLAYBACK_2 = 0x8,
+  CEC_ADDR_RECORDING_3 = 0x9,
+  CEC_ADDR_TUNER_4 = 0xA,
+  CEC_ADDR_PLAYBACK_3 = 0xB,
+  CEC_ADDR_RESERVED_1 = 0xC,
+  CEC_ADDR_RESERVED_2 = 0xD,
+  CEC_ADDR_FREE_USE = 0xE,
+  CEC_ADDR_BROADCAST = 0xF,
+};
+
+enum CecOpcode : uint8_t {
+  CEC_OPCODE_FEATURE_ABORT = 0x00,
+  CEC_OPCODE_GIVE_OSD_NAME = 0x46,
+  CEC_OPCODE_SET_OSD_NAME = 0x47,
+  CEC_OPCODE_GIVE_PHYSICAL_ADDRESS = 0x83,
+  CEC_OPCODE_REPORT_PHYSICAL_ADDRESS = 0x84,
+  CEC_OPCODE_GIVE_DEVICE_POWER_STATUS = 0x8F,
+  CEC_OPCODE_REPORT_POWER_STATUS = 0x90,
+  CEC_OPCODE_CEC_VERSION = 0x9E,
+  CEC_OPCODE_GET_CEC_VERSION = 0x9F,
+};
+
+enum CecVersion : uint8_t {
+  CEC_VERSION_1_1 = 0x00,
+  CEC_VERSION_1_2 = 0x01,
+  CEC_VERSION_1_2A = 0x02,
+  CEC_VERSION_1_3 = 0x03,
+  CEC_VERSION_1_3A = 0x04,
+  CEC_VERSION_1_4 = 0x05,
+  CEC_VERSION_2_0 = 0x06,
+};
+
+enum CecPowerStatus : uint8_t {
+  CEC_POWER_STATUS_ON = 0x00,
+  CEC_POWER_STATUS_STANDBY = 0x01,
+  CEC_POWER_STATUS_IN_TRANSITION_TO_ON = 0x02,
+  CEC_POWER_STATUS_IN_TRANSITION_TO_STANDBY = 0x03,
+};
+
+enum CecDeviceType : uint8_t {
+  CEC_DEVICE_TYPE_TV = 0x00,
+  CEC_DEVICE_TYPE_RECORDING = 0x01,
+  CEC_DEVICE_TYPE_TUNER = 0x03,
+  CEC_DEVICE_TYPE_PLAYBACK = 0x04,
+  CEC_DEVICE_TYPE_AUDIO_SYSTEM = 0x05,
+  CEC_DEVICE_TYPE_OTHER = 0xFF,
+};
+
+enum CecAbortReason : uint8_t {
+  CEC_ABORT_UNRECOGNIZED_OPCODE = 0x00,
+  CEC_ABORT_NOT_IN_CORRECT_MODE = 0x01,
+  CEC_ABORT_CANNOT_PROVIDE_SOURCE = 0x02,
+  CEC_ABORT_INVALID_OPERAND = 0x03,
+  CEC_ABORT_REFUSED = 0x04,
+};
+
 class Frame : public std::vector<uint8_t> {
  public:
   Frame() = default;
@@ -18,7 +83,7 @@ class Frame : public std::vector<uint8_t> {
   uint8_t initiator_addr() const { return (this->at(0) >> 4) & 0xf; }
   uint8_t destination_addr() const { return this->at(0) & 0xf; }
   uint8_t opcode() const { return (this->size() >= 2) ? this->at(1) : 0; }
-  bool is_broadcast() const { return this->destination_addr() == 0xf; }
+  bool is_broadcast() const { return this->destination_addr() == CEC_ADDR_BROADCAST; }
   std::string to_string(bool skip_decode = 0) const;
   constexpr static int MAX_LENGTH = 16;  // from HDMI CEC standard 1.4
 };

--- a/demo.yaml
+++ b/demo.yaml
@@ -38,7 +38,6 @@ captive_portal:
 
 hdmi_cec:
   pin: GPIO26
-  address: 0x5
   physical_address: 0x4000
   on_message:
     # Volume Up

--- a/demo.yaml
+++ b/demo.yaml
@@ -8,6 +8,8 @@ external_components:
 
 esp32:
   board: esp32dev
+  framework:
+    type: esp-idf
 
 # Enable logging
 logger:

--- a/demo.yaml
+++ b/demo.yaml
@@ -60,3 +60,24 @@ hdmi_cec:
     - data: [0x44, 0x43]
       then:
         - logger.log: "Mute"
+
+  devices:
+    - id: bluray
+      name: "Blu-ray Player"
+      match:
+        osd_name: "BD Player"
+      power_switch:
+      osd_name_sensor:
+      power_status_sensor:
+      active_source_sensor:
+      last_seen_sensor:
+      navigation_buttons:
+      transport_buttons:
+
+    - id: soundbar
+      name: "Soundbar"
+      match:
+        vendor_id: 0x0000F0
+        device_type: audio_system
+      power_switch:
+      volume_buttons:

--- a/demo.yaml
+++ b/demo.yaml
@@ -18,17 +18,8 @@ logger:
 api:
   encryption:
     key: !secret encryption_key
-  services:
-    - service: hdmi_cec_send
-      variables:
-        cec_source: int
-        cec_destination: int
-        cec_data: int[]
-      then:
-        - hdmi_cec.send:
-            source: !lambda "return static_cast<unsigned char>(cec_source);"
-            destination: !lambda "return static_cast<unsigned char>(cec_destination);"
-            data: !lambda "std::vector<unsigned char> charVector; for (int i : cec_data) { charVector.push_back(static_cast<unsigned char>(i)); } return charVector;"
+  # Enable CEC services (send, etc.) in Home Assistant
+  custom_services: true
 
 # Enable OTA
 ota:

--- a/demo.yaml
+++ b/demo.yaml
@@ -18,7 +18,7 @@ logger:
 api:
   encryption:
     key: !secret encryption_key
-  # Enable CEC services (send, etc.) in Home Assistant
+  # Enable CEC services (send, scan_bus, etc.) in Home Assistant
   custom_services: true
 
 # Enable OTA
@@ -37,8 +37,14 @@ wifi:
 captive_portal:
 
 hdmi_cec:
+  id: cec
   pin: GPIO26
   physical_address: 0x4000
+  scan_on_boot: true
+  scan_boot_delay: 3s
+  on_scan_complete:
+    - then:
+        - logger.log: "CEC bus scan complete"
   on_message:
     # Volume Up
     - data: [0x44, 0x41]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773597492,
+        "narHash": "sha256-hQ284SkIeNaeyud+LS0WVLX+WL2rxcVZLFEaK0e03zg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a07d4ce6bee67d7c838a8a5796e75dff9caa21ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773297127,
+        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,73 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      treefmt-nix,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        treefmtEval = treefmt-nix.lib.evalModule pkgs {
+          projectRootFile = "flake.nix";
+          programs.nixfmt.enable = true;
+          programs.clang-format.enable = true;
+          programs.ruff-format.enable = true;
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            clang-tools
+            esphome
+            nixfmt
+            ruff
+          ];
+        };
+
+        formatter = treefmtEval.config.build.wrapper;
+
+        checks.formatting = treefmtEval.config.build.check self;
+
+        # esphome compile requires network access, so use
+        # `nix run .#check` from the project root.
+        packages.check = pkgs.writeShellApplication {
+          name = "check";
+          runtimeInputs = with pkgs; [ esphome ];
+          text =
+            let
+              dummy_secrets = builtins.toFile "secrets.yaml" ''
+                encryption_key: "qBeQ7x+DSLlOjQOCUkm513o9DTEugk6Ze/JHkMuK4DE="
+                mgmt_pass: "test_password"
+                wifi_ssid: "TestNetwork"
+                wifi_password: "test_wifi_password"
+              '';
+            in
+            ''
+              set -euo pipefail
+              if [ ! -f secrets.yaml ]; then
+                echo "Creating dummy secrets.yaml for build testing..."
+                cp ${dummy_secrets} secrets.yaml
+              fi
+              echo "=== Checking formatting ==="
+              nix fmt -- --fail-on-change
+              echo "=== Compiling demo.yaml ==="
+              esphome compile demo.yaml
+              echo "=== All checks passed ==="
+            '';
+        };
+      }
+    );
+}

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,1 @@
+line-length = 120


### PR DESCRIPTION
This includes a lot of things. I'm throwing them all up for PR at once together, and if you want them all, great! If you want to discuss/cherry pick, we can talk about that.

Included:
- Some simple build tooling: a nix flake + direnv with helpers for formatting and doing a test build. Added fomatting rules that follow existing convention closely, but did clean up formatting.
- Fixed typos and cleaned up bogus characters in CEC decoder
- Added NVIDIA and Roku to the vendors list
- Did some memory optimization - replaced maps with sorted lists. Slightly more compute cycles spent (but generally not a bottleneck) to save heap space (at a premium)
- Added enums for things to make the code more self-documenting
- Exposes a compatible service to Home Assistant so users don't have to do that manually
- Implement auto-negotiation of the logical CEC address. Incidentally, the current default of 0x5 is _terrible_ since that will collide with _any_ receiver or soundbar.
- Implement bus scanning and device discovery. This allows addressing devices by something more stable than logical address (especially when some dummy plugs in a dongle that hard-codes its address to 0x5.) Also supports monitoring of device power states.
- Allow creation of ESPHome sub-devices to represent devices on the HDMI network, logically-addressed. Supports auto-creation of various classes of useful entities.