### PR TITLE
Fix hdmi_cec.send when source is omitted on ESPHome 2026.4.0

### DIFF
--- a/components/hdmi_cec/__init__.py
+++ b/components/hdmi_cec/__init__.py
@@ -140,8 +140,8 @@ async def send_action_to_code(config, action_id, template_args, args):
     parent = await cg.get_variable(config[CONF_PARENT])
     var = cg.new_Pvariable(action_id, template_args, parent)
 
-    source_template_ = await cg.templatable(config.get(CONF_SOURCE), args, cg.uint8)
-    if source_template_ is not None:
+    if CONF_SOURCE in config:
+        source_template_ = await cg.templatable(config[CONF_SOURCE], args, cg.uint8)
         cg.add(var.set_source(source_template_))
 
     destination_template_ = await cg.templatable(config.get(CONF_DESTINATION), args, cg.uint8)


### PR DESCRIPTION
## Summary
- `cg.templatable` in ESPHome 2026.4.0 rejects `None`, so omitting `source:` on `hdmi_cec.send` now crashes codegen with `ValueError: Object is not an expression`.
- Skip the `cg.templatable` / `set_source` calls entirely when `source` is absent. `SendAction::play` already falls back to `parent_->address()` in that case, so behavior is unchanged on older ESPHome versions.

Fixes #47

## Test plan
- [x] Compile a config that uses `hdmi_cec.send` without an explicit `source:` on ESPHome 2026.4.0
- [x] Compile a config that sets `source:` explicitly (templated and literal) to confirm no regression