### PR TITLE
fix: prevent crash and watchdog reset when sending CEC frames (Ai helped)

### DIFF
--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -19,6 +19,13 @@ static const uint32_t HIGH_BIT_US = 600;
 static const uint32_t LOW_BIT_US = 1500;
 // arbitration and retransmission
 static const size_t MAX_ATTEMPTS = 5;
+// Yield interval for bus-free wait loop: break long waits into chunks of this
+// duration and call yield() between each, so the FreeRTOS scheduler can run
+// other tasks and the Task Watchdog Timer is not triggered.
+// 1ms is a good trade-off: short enough to maintain CEC timing accuracy
+// (bus-free periods are 7200-16800µs), yet long enough to avoid excessive
+// context-switch overhead from yielding on every microsecond-scale iteration.
+static const uint32_t YIELD_INTERVAL_US = 1000;
 
 static const gpio::Flags INPUT_MODE_FLAGS = gpio::FLAG_INPUT | gpio::FLAG_PULLUP;
 static const gpio::Flags OUTPUT_MODE_FLAGS = gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN;
@@ -259,8 +266,8 @@ bool HDMICEC::send(uint8_t source, uint8_t destination, const std::vector<uint8_
           break;
         }
         ESP_LOGV(TAG, "HDMICEC::send(): waiting %d usec for bus free period", delay);
-        if (delay >= 1000) {
-          delay_microseconds_safe(1000);
+        if (delay >= (int32_t) YIELD_INTERVAL_US) {
+          delay_microseconds_safe(YIELD_INTERVAL_US);
           yield();
         } else {
           delay_microseconds_safe(delay);

--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -237,14 +237,45 @@ bool HDMICEC::send(uint8_t source, uint8_t destination, const std::vector<uint8_
     //  - 3 bit periods for resend of a failed transmission attempt
     uint8_t free_bit_periods = (last_sent_us_ > last_falling_edge_us_) ? 7 : 5;
 
+    // Total timeout: abort if we can't send within 2 seconds (prevents infinite blocking on busy bus)
+    static const uint32_t SEND_TIMEOUT_US = 2000000;
+    const uint32_t send_start_us = micros();
+
     for (size_t i = 0; i < MAX_ATTEMPTS; i++) {
       int32_t delay = 0;
-      while ((delay = free_bit_periods * TOTAL_BIT_US + std::max(last_sent_us_, last_falling_edge_us_) - micros()) > 0) {
+      // Per-attempt timeout for bus-free wait: 200ms max per attempt
+      const uint32_t attempt_start_us = micros();
+      static const uint32_t ATTEMPT_TIMEOUT_US = 200000;
+
+      while ((delay = free_bit_periods * TOTAL_BIT_US + std::max(last_sent_us_, (uint32_t) last_falling_edge_us_) - micros()) > 0) {
+        // Check total timeout
+        if ((micros() - send_start_us) > SEND_TIMEOUT_US) {
+          ESP_LOGW(TAG, "HDMICEC::send(): total timeout reached (2s), aborting");
+          return false;
+        }
+        // Check per-attempt timeout (bus constantly busy)
+        if ((micros() - attempt_start_us) > ATTEMPT_TIMEOUT_US) {
+          ESP_LOGW(TAG, "HDMICEC::send(): attempt %d bus-wait timeout (200ms), retrying", i + 1);
+          break;
+        }
         ESP_LOGV(TAG, "HDMICEC::send(): waiting %d usec for bus free period", delay);
-        delay_microseconds_safe(delay);
+        if (delay >= 1000) {
+          delay_microseconds_safe(1000);
+          yield();
+        } else {
+          delay_microseconds_safe(delay);
+        }
         // Note: during this delay, the 'last_falling_edge_us_' might be incremented by 'gpio_intr_', requiring further wait
         free_bit_periods = 5;
       }
+
+      // Skip frame send if we broke out due to per-attempt timeout
+      if ((micros() - attempt_start_us) > ATTEMPT_TIMEOUT_US) {
+        free_bit_periods = 3;
+        yield();
+        continue;
+      }
+
       ESP_LOGV(TAG, "HDMICEC::send(): bus available, sending frame...");
 
       auto result = send_frame_(frame, is_broadcast);
@@ -256,10 +287,11 @@ bool HDMICEC::send(uint8_t source, uint8_t destination, const std::vector<uint8_
                ((result == SendResult::BusCollision) ? "Bus Collision" : "No Ack received"));
       // attempt retransmission with smaller free time gap
       free_bit_periods = 3;
+      yield();
     }
   }
 
-  ESP_LOGE(TAG, "HDMICEC::send(): send failed after five attempts");
+  ESP_LOGE(TAG, "HDMICEC::send(): send failed after %d attempts", MAX_ATTEMPTS);
   return false;
 }
 

--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -263,7 +263,7 @@ bool HDMICEC::send(uint8_t source, uint8_t destination, const std::vector<uint8_
   return false;
 }
 
-SendResult IRAM_ATTR HDMICEC::send_frame_(const Frame &frame, bool is_broadcast) {
+SendResult HDMICEC::send_frame_(const Frame &frame, bool is_broadcast) {
   pin_->detach_interrupt();  // do NOT listen for pin changes while sending
   auto result = SendResult::Success;
 
@@ -310,7 +310,7 @@ SendResult IRAM_ATTR HDMICEC::send_frame_(const Frame &frame, bool is_broadcast)
   return result;
 }
 
-bool IRAM_ATTR HDMICEC::send_start_bit_() {
+bool HDMICEC::send_start_bit_() {
   // 1. pull low for 3700 us
   set_pin_output_low();
   delay_microseconds_safe(3700);
@@ -332,7 +332,7 @@ bool IRAM_ATTR HDMICEC::send_start_bit_() {
   return success;
 }
 
-void IRAM_ATTR HDMICEC::send_bit_(bool bit_value) {
+void HDMICEC::send_bit_(bool bit_value) {
   // total bit duration:
   // logic 1: pull low for 600 us, then pull high for 1800 us
   // logic 0: pull low for 1500 us, then pull high for 900 us
@@ -346,7 +346,7 @@ void IRAM_ATTR HDMICEC::send_bit_(bool bit_value) {
   delay_microseconds_safe(high_duration_us);
 }
 
-bool IRAM_ATTR HDMICEC::send_high_and_test_() {
+bool HDMICEC::send_high_and_test_() {
   uint32_t start_us = micros();
 
   // send a Logical 1

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -128,7 +128,7 @@ protected:
   std::vector<MessageTrigger*> message_triggers_;
 
   bool last_level_ = true;            // cec line level on last isr call
-  uint32_t last_falling_edge_us_ = 0; // timepoint in received message
+  volatile uint32_t last_falling_edge_us_ = 0; // timepoint in received message (volatile: written by ISR, read by send())
   uint32_t last_sent_us_ = 0;         // timepoint on end of sent message
   ReceiverState receiver_state_;
   uint8_t recv_bit_counter_ = 0;


### PR DESCRIPTION
## Description

### Problem

Sending a CEC command (e.g. `hdmi_cec.send` with opcode `0x8F` — Give Device Power Status) causes an **immediate ESP32 crash/reboot** on ESP-IDF framework. Two distinct issues were identified:

1. **Flash cache instruction fetch error** — The transmitter functions (`send_frame_`, `send_start_bit_`, `send_bit_`, `send_high_and_test_`) are marked `IRAM_ATTR`, but they call functions that reside in Flash memory (`pin_->digital_read()`, `delay_microseconds_safe()`, `pin_->detach_interrupt()`, etc.). When the CPU executes IRAM code that references Flash and the Flash cache happens to be disabled, the ESP32 triggers an instruction fetch error and crashes.

2. **Task Watchdog Timer reset** — The `send()` function busy-waits using `delay_microseconds_safe()` for up to 16.8ms per attempt (7 × 2400µs) across 5 retry attempts without ever yielding to the FreeRTOS scheduler. On a busy CEC bus where `last_falling_edge_us_` keeps being updated by the ISR, the inner while loop can block indefinitely, triggering the Task Watchdog.

### Root Cause Analysis

The transmitter functions **do not need `IRAM_ATTR`**. Unlike `gpio_intr_` (the ISR) which must execute from IRAM, the send functions are always called from normal task context (via HA API calls, template buttons, or built-in handlers in `loop()`). The `IRAM_ATTR` attribute on these functions is unnecessary and actively harmful.

Additionally, `last_falling_edge_us_` is written by the ISR and read by `send()` in task context, but is not declared `volatile`. The compiler may cache its value in a register, preventing the while loop from ever seeing ISR updates.

### Changes

#### `hdmi_cec.cpp`

1. **Remove `IRAM_ATTR`** from `send_frame_()`, `send_start_bit_()`, `send_bit_()`, and `send_high_and_test_()`
   - These run in task context, not ISR context
   - `IRAM_ATTR` is preserved on `gpio_intr_()`, `reset_state_variables_()`, `set_pin_input_high()`, and `set_pin_output_low()` which ARE called from the ISR

2. **Add `yield()` calls** in the bus-free wait loop and after failed send attempts
   - Prevents Task Watchdog reset by giving the FreeRTOS scheduler a chance to run
   - For delays ≥ 1ms, waits in 1ms increments with `yield()` between each

3. **Add timeout guards** to prevent infinite blocking:
   - **Total timeout**: 2 seconds for the entire `send()` call
   - **Per-attempt timeout**: 200ms for each bus-free wait period
   - If the bus is constantly busy (another device transmitting non-stop), `send()` will abort gracefully instead of blocking forever

#### `hdmi_cec.h`

4. **Add `volatile` qualifier** to `last_falling_edge_us_`
   - This variable is written by `gpio_intr_` (ISR context) and read by `send()` (task context)
   - Without `volatile`, the compiler may optimize away re-reads inside the while loop

### Testing

- Tested on ESP32 (esp32dev) with ESP-IDF 5.5.4 and ESPHome 2026.4.5
- Compiled successfully with 0 errors, 0 warnings
- Flashed via OTA and verified stable CEC send operations (Give Device Power Status, Standby, etc.)
- No more crashes or watchdog resets observed
