### PR TITLE
fix(cec_decoder): fix nullptr crashes from array size/initializer mismatches

### DIFF
--- a/components/hdmi_cec/cec_decoder.cpp
+++ b/components/hdmi_cec/cec_decoder.cpp
@@ -155,12 +155,12 @@ template<uint32_t OPERANDS> bool Decoder::do_operand() {
 template<> bool Decoder::do_operand<Decoder::None>() { return append_operand(""); }
 
 template<> bool Decoder::do_operand<Decoder::AbortReason>() {
-  const static std::array<const char *, 7> names = {"Unrecognized opcode",
-                                                    "Not in correct mode to respond",
-                                                    "Cannot provide source",
-                                                    "Invalid operand",
-                                                    "Refused",
-                                                    "Unable to determine"};
+  const static std::array<const char *, 6> names = {"Unrecognized opcode",
+                                                    "Not in correct mode to respond",
+                                                    "Cannot provide source",
+                                                    "Invalid operand",
+                                                    "Refused",
+                                                    "Unable to determine"};
   return append_operand<names.size()>(names);
 }
 
@@ -185,15 +185,15 @@ template<> bool Decoder::do_operand<Decoder::AudioStatus>() {
 }
 
 template<> bool Decoder::do_operand<Decoder::DeviceType>() {
-  const static std::array<const char *, 9> names = {"TV]",           "Recording Device]", "Reserved",
-                                                    "Tuner",       "Playback Device", "Audio System",
+  const static std::array<const char *, 8> names = {"TV",           "Recording Device", "Reserved",
+                                                    "Tuner",       "Playback Device", "Audio System",
                                                     "Pure CEC Switch", "Video Processor"};
   return append_operand<names.size()>(names);
 }
 
 template<> bool Decoder::do_operand<Decoder::DisplayControl>() {
-  const static std::array<const char *, 9> names = {"Default Time", "Until cleared", "Clear previous",
-                                                    "Reserved"};
+  const static std::array<const char *, 4> names = {"Default Time", "Until cleared", "Clear previous",
+                                                    "Reserved"};
   return append_operand<names.size()>(names);
 }
 
@@ -229,7 +229,7 @@ template<> bool Decoder::do_operand<Decoder::PhysicalAddress>() {
 }
 
 template<> bool Decoder::do_operand<Decoder::PowerStatus>() {
-  const static std::array<const char *, 5> names = {"On", "Standby", "Standby->On", "On->Standby"};
+  const static std::array<const char *, 4> names = {"On", "Standby", "Standby->On", "On->Standby"};
   return append_operand<names.size()>(names);
 }
 
@@ -268,7 +268,7 @@ template<> bool Decoder::do_operand<Decoder::ShortAudioDescriptor>() {
 }
 
 template<> bool Decoder::do_operand<Decoder::SystemAudioStatus>() {
-  const static std::array<const char *, 3> names = {"Off", "On"};
+  const static std::array<const char *, 2> names = {"Off", "On"};
   return append_operand<names.size()>(names);
 }
 
@@ -425,7 +425,14 @@ const char *Decoder::find_opcode_name(uint32_t opcode) const {
    * @return true if a further operand can be decoded, false otherwise
    */
   bool Decoder::append_operand(const char *word, uint8_t offset_incr /* default 1 */) {
-    length_ += snprintf(&line_[length_], (line_.size() - length_), "[%s]", word);
+    if (length_ < line_.size()) {
+      int written = snprintf(&line_[length_], (line_.size() - length_), "[%s]", word);
+      if (written > 0) {
+        length_ += (unsigned int) written;
+        if (length_ > line_.size())
+          length_ = line_.size();  // clamp: snprintf returns desired length, not actual written
+      }
+    }
     offset_ += offset_incr;
     return (length_ < line_.size()) && (offset_ < frame_.size());
   }

--- a/components/hdmi_cec/cec_decoder.h
+++ b/components/hdmi_cec/cec_decoder.h
@@ -133,9 +133,12 @@ class Decoder {
   bool append_operand(const char *word, uint8_t offset_incr = 1);
 
   template<uint32_t N_STRINGS> bool append_operand(const std::array<const char *, N_STRINGS> &strings) {
+    if (offset_ >= frame_.size()) {
+      return append_operand("?");
+    }
     uint32_t operand_value = frame_[offset_];
-    const char *s = (operand_value < N_STRINGS) ? strings[operand_value] : "?";
-    return append_operand(s);
+    const char *s = (operand_value < N_STRINGS) ? strings[operand_value] : nullptr;
+    return append_operand(s ? s : "?");  // null-guard: nullptr entry in array -> "?"
   }
 
   /**


### PR DESCRIPTION
## Problem

The CEC decoder crashes with a `LoadProhibited` fault on ESP32 when receiving
frames containing reserved or out-of-range operand values (e.g. `Report Physical
Address` with DeviceType=8, sent by certain devices including NVIDIA Shield).

Root cause: five `std::array<const char*, N>` lookup tables declare a size `N`
larger than their initializer list. Uninitialized entries are zero-initialized
to `nullptr`. When a received frame contains an operand value that maps to one
of these `nullptr` slots, it gets passed to `snprintf("[%s]", nullptr)` →
`LoadProhibited` crash.

A secondary issue in `append_operand()`: `snprintf` returns the *desired* write
length, not the actual bytes written. Accumulating this into `length_` without
clamping can push it past the 256-byte `line_` buffer boundary, causing an
out-of-bounds write on subsequent calls.

## Fixes

**`cec_decoder.cpp`** — correct array sizes to match actual initializer counts:

| Function | Was | Now |
|---|---|---|
| `do_operand<AbortReason>` | 7 | 6 |
| `do_operand<DeviceType>` | 9 | 8 |
| `do_operand<DisplayControl>` | 9 | 4 |
| `do_operand<PowerStatus>` | 5 | 4 |
| `do_operand<SystemAudioStatus>` | 3 | 2 |

Also fixes two typos (`"TV]"` → `"TV"`, `"Recording Device]"` →
`"Recording Device"`) and removes stray non-ASCII bytes (U+0093/U+0094)
that were embedded in several string literals.

`append_operand()`: clamp `length_` after `snprintf` to prevent unsigned
overflow past `line_.size()`.

**`cec_decoder.h`** — add null-guard in `append_operand<N>` template: if a
lookup returns `nullptr` (e.g. from a future array size regression), fall back
to `"?"` instead of crashing.

## Tested

Verified on ESP32 WROOM (D1 Mini32) running ESPHome 2026.5.3 / ESP-IDF 5.5.4
in `monitor_mode: true`. Before fix: reproducible `LoadProhibited` crash within
seconds of boot. After fix: stable boot confirmed by Safe Mode counter reset,
frames with DeviceType=8 correctly decoded as `[?]`.

## Related

- Partially overlaps with the CEC decoder cleanup in #46 (bogus characters,
  typos), but that PR does not address the array size mismatches or the
  `append_operand` overflow.
- #49 fixes a separate crash (WDT reset when sending CEC frames) and is
  orthogonal to this PR.

## Notes

Debugged and fixed with assistance from Claude (Anthropic).