### PR TITLE
[hdmi_cec] implement proper freertos task handling to make cec work non-blocking

### DIFF
--- a/components/hdmi_cec/__init__.py
+++ b/components/hdmi_cec/__init__.py
@@ -1,10 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome import pins, automation
-from esphome.const import (
-    CONF_ID,
-    CONF_TRIGGER_ID
-)
+from esphome import automation, pins
+from esphome.const import CONF_ID, CONF_TRIGGER_ID
+from esphome.core import CORE
 
 CODEOWNERS = ["@Palakis"]
 
@@ -73,9 +71,7 @@ CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_OSD_NAME, "esphome"): validate_osd_name,
         # Sending occupies a core for the length of the frame. A build that also does
         # real-time work wants that core to be the other one; -1 leaves it to the scheduler.
-        cv.Optional(CONF_TX_CORE, -1): cv.All(
-            cv.only_on_esp32, cv.int_range(min=-1, max=1)
-        ),
+        cv.Optional(CONF_TX_CORE): cv.All(cv.only_on_esp32, cv.int_range(min=-1, max=1)),
         cv.Optional(CONF_ON_SEND_RESULT): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(SendResultTrigger),
@@ -96,9 +92,18 @@ CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend(
     }
 )
 
+# Platforms whose toolchain provides the FreeRTOS task API the transmit and receive paths
+# are built on.
+def has_freertos():
+    return CORE.is_esp32
+
+
 async def to_code(config):
     if config[CONF_DECODE_MESSAGES] == True:
         cg.add_define('USE_CEC_DECODER')
+
+    if has_freertos():
+        cg.add_define('HDMI_CEC_USE_FREERTOS')
 
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)

--- a/components/hdmi_cec/__init__.py
+++ b/components/hdmi_cec/__init__.py
@@ -16,6 +16,8 @@ CONF_MONITOR_MODE = "monitor_mode"
 CONF_DECODE_MESSAGES = "decode_messages"
 CONF_OSD_NAME = "osd_name"
 CONF_ON_MESSAGE = "on_message"
+CONF_ON_SEND_RESULT = "on_send_result"
+CONF_TX_CORE = "tx_core"
 
 CONF_SOURCE = "source"
 CONF_DESTINATION = "destination"
@@ -51,6 +53,10 @@ HDMICEC = hdmi_cec_ns.class_(
 MessageTrigger = hdmi_cec_ns.class_(
     "MessageTrigger", automation.Trigger.template(cg.uint8, cg.uint8, cg.std_vector.template(cg.uint8))
 )
+SendResultTrigger = hdmi_cec_ns.class_(
+    "SendResultTrigger",
+    automation.Trigger.template(cg.uint8, cg.uint8, cg.std_vector.template(cg.uint8), cg.bool_)
+)
 SendAction = hdmi_cec_ns.class_(
     "SendAction", automation.Action
 )
@@ -65,6 +71,19 @@ CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_MONITOR_MODE, False): cv.boolean,
         cv.Optional(CONF_DECODE_MESSAGES, True): cv.boolean,
         cv.Optional(CONF_OSD_NAME, "esphome"): validate_osd_name,
+        # Sending occupies a core for the length of the frame. A build that also does
+        # real-time work wants that core to be the other one; -1 leaves it to the scheduler.
+        cv.Optional(CONF_TX_CORE, -1): cv.All(
+            cv.only_on_esp32, cv.int_range(min=-1, max=1)
+        ),
+        cv.Optional(CONF_ON_SEND_RESULT): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(SendResultTrigger),
+                cv.Optional(CONF_SOURCE): cv.int_range(min=0, max=15),
+                cv.Optional(CONF_DESTINATION): cv.int_range(min=0, max=15),
+                cv.Optional(CONF_OPCODE): cv.uint8_t,
+            }
+        ),
         cv.Optional(CONF_ON_MESSAGE): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MessageTrigger),
@@ -91,6 +110,9 @@ async def to_code(config):
     cg.add(var.set_physical_address(config[CONF_PHYSICAL_ADDRESS]))
     cg.add(var.set_promiscuous_mode(config[CONF_PROMISCUOUS_MODE]))
     cg.add(var.set_monitor_mode(config[CONF_MONITOR_MODE]))
+
+    if (tx_core := config.get(CONF_TX_CORE)) is not None:
+        cg.add(var.set_tx_core(tx_core))
 
     osd_name_bytes = bytes(config[CONF_OSD_NAME], 'ascii', 'ignore') # convert string to ascii bytes
     osd_name_bytes = [x for x in osd_name_bytes] # convert byte array to int array
@@ -122,6 +144,32 @@ async def to_code(config):
                 (cg.uint8, "source"),
                 (cg.uint8, "destination"),
                 (cg.std_vector.template(cg.uint8), "data")
+            ],
+            conf
+        )
+
+    for conf in config.get(CONF_ON_SEND_RESULT, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+
+        source = conf.get(CONF_SOURCE)
+        if source is not None:
+            cg.add(trigger.set_source(source))
+
+        destination = conf.get(CONF_DESTINATION)
+        if destination is not None:
+            cg.add(trigger.set_destination(destination))
+
+        opcode = conf.get(CONF_OPCODE)
+        if opcode is not None:
+            cg.add(trigger.set_opcode(opcode))
+
+        await automation.build_automation(
+            trigger,
+            [
+                (cg.uint8, "source"),
+                (cg.uint8, "destination"),
+                (cg.std_vector.template(cg.uint8), "data"),
+                (cg.bool_, "success")
             ],
             conf
         )

--- a/components/hdmi_cec/cec_decoder.cpp
+++ b/components/hdmi_cec/cec_decoder.cpp
@@ -308,7 +308,7 @@ template<> bool Decoder::do_operand<Decoder::VendorId>() {
   if (it == vendor_ids.end()) {
     // if the hdmi-cec vendor id is not in our list, the id value itself is printed.
     char line[12];
-    sprintf(line, "ID=%06x", id);
+    sprintf(line, "ID=%06lx", id);
     return append_operand(line, 3);
   }
   return append_operand(it->second, 3);

--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -11,6 +11,13 @@ namespace esphome {
 namespace hdmi_cec {
 
 static const char *const TAG = "hdmi_cec";
+
+// Where the decoder runs in a task it does not belong in IRAM.
+#ifdef HDMI_CEC_USE_FREERTOS
+#define HDMI_CEC_RX_ATTR
+#else
+#define HDMI_CEC_RX_ATTR IRAM_ATTR
+#endif
 // receiver constants
 static const uint32_t START_BIT_MIN_US = 3500;
 static const uint32_t HIGH_BIT_MIN_US = 400;
@@ -79,7 +86,7 @@ void HDMICEC::setup() {
   frames_queue_.reset();
   tx_results_.reserve(MAX_FRAMES_TO_SEND);
 
-#ifdef USE_ESP32
+#ifdef HDMI_CEC_USE_FREERTOS
   tx_queue_ = xQueueCreate(MAX_FRAMES_TO_SEND, sizeof(TxRecord));
   if (tx_queue_ == nullptr) {
     ESP_LOGE(TAG, "could not create the transmit queue");
@@ -96,13 +103,49 @@ void HDMICEC::setup() {
     this->mark_failed();
     return;
   }
+
+  created = (tx_core_ < 0) ? xTaskCreate(HDMICEC::rx_task_entry_, "hdmi_cec_rx", RX_TASK_STACK_WORDS, this,
+                                         RX_TASK_PRIORITY, &rx_task_)
+                           : xTaskCreatePinnedToCore(HDMICEC::rx_task_entry_, "hdmi_cec_rx", RX_TASK_STACK_WORDS, this,
+                                                     RX_TASK_PRIORITY, &rx_task_, tx_core_);
+  if (created != pdPASS) {
+    ESP_LOGE(TAG, "could not create the receive task");
+    this->mark_failed();
+    return;
+  }
 #endif
 
   pin_->attach_interrupt(HDMICEC::gpio_intr_, this, gpio::INTERRUPT_ANY_EDGE);
   set_pin_input_high();
 }
 
-#ifdef USE_ESP32
+#ifdef HDMI_CEC_USE_FREERTOS
+void HDMICEC::rx_task_entry_(void *param) { static_cast<HDMICEC *>(param)->rx_task_loop_(); }
+
+void HDMICEC::rx_task_loop_() {
+  while (true) {
+    ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+
+    if (edge_overflow_.exchange(false)) {
+      ESP_LOGW(TAG, "edge queue overflow, dropping the frame in flight");
+      receiver_state_ = ReceiverState::Idle;
+      recv_ack_queued_ = false;
+      frame_receive_ = nullptr;
+      reset_state_variables_(this);
+    }
+
+    while (true) {
+      const uint16_t tail = edge_tail_.load(std::memory_order_relaxed);
+      if (tail == edge_head_.load(std::memory_order_acquire)) {
+        break;
+      }
+      const EdgeEvent event = edge_queue_[tail];
+      edge_tail_.store((uint16_t) ((tail + 1) % EDGE_QUEUE_SIZE), std::memory_order_release);
+      process_edge_(this, event.level, event.us);
+    }
+  }
+}
+
 void HDMICEC::tx_task_entry_(void *param) { static_cast<HDMICEC *>(param)->tx_task_loop_(); }
 
 void HDMICEC::tx_task_loop_() {
@@ -183,7 +226,7 @@ void HDMICEC::dump_config() {
   ESP_LOGCONFIG(TAG, "  address: %x", address_);
   ESP_LOGCONFIG(TAG, "  promiscuous mode: %s", (promiscuous_mode_ ? "yes" : "no"));
   ESP_LOGCONFIG(TAG, "  monitor mode: %s", (monitor_mode_ ? "yes" : "no"));
-#ifdef USE_ESP32
+#ifdef HDMI_CEC_USE_FREERTOS
   if (tx_core_ < 0) {
     ESP_LOGCONFIG(TAG, "  transmit task core: any");
   } else {
@@ -345,7 +388,7 @@ bool HDMICEC::send(uint8_t source, uint8_t destination, const std::vector<uint8_
     return false;
   }
 
-#ifdef USE_ESP32
+#ifdef HDMI_CEC_USE_FREERTOS
   TxRecord request;
   request.length = (uint8_t) frame.size();
   std::copy(frame.begin(), frame.end(), request.bytes);
@@ -398,7 +441,7 @@ SendResult HDMICEC::send_with_retries_(const Frame &frame, bool is_broadcast) {
         }
         ESP_LOGV(TAG, "HDMICEC::send(): waiting %d usec for bus free period", delay);
         if (delay >= (int32_t) YIELD_INTERVAL_US) {
-#ifdef USE_ESP32
+#ifdef HDMI_CEC_USE_FREERTOS
           // A bus-free period is 12000-16800 us, so the millisecond granularity of a tick
           // costs nothing here and the core is free for other work meanwhile. Bit timing
           // below stays on delay_microseconds_safe(); 2400 us is not schedulable.
@@ -554,24 +597,61 @@ void IRAM_ATTR HDMICEC::gpio_intr_(HDMICEC *self) {
   }
   self->last_level_ = level;
 
-  // on falling edge, store current time as the start of the low pulse
   if (level == false) {
     self->last_falling_edge_us_ = now;
+  }
+
+#ifdef HDMI_CEC_USE_FREERTOS
+  const uint16_t head = self->edge_head_.load(std::memory_order_relaxed);
+  const uint16_t next = (uint16_t) ((head + 1) % EDGE_QUEUE_SIZE);
+  if (next == self->edge_tail_.load(std::memory_order_acquire)) {
+    self->edge_overflow_.store(true, std::memory_order_relaxed);
+    return;
+  }
+  self->edge_queue_[head].us = now;
+  self->edge_queue_[head].level = level;
+  self->edge_head_.store(next, std::memory_order_release);
+
+  BaseType_t higher_woken = pdFALSE;
+  vTaskNotifyGiveFromISR(self->rx_task_, &higher_woken);
+  if (higher_woken == pdTRUE) {
+    portYIELD_FROM_ISR();
+  }
+#else
+  process_edge_(self, level, now);
+#endif
+}
+
+void HDMI_CEC_RX_ATTR HDMICEC::drive_ack_(HDMICEC *self, uint32_t edge_us) {
+#ifdef HDMI_CEC_USE_FREERTOS
+  self->set_pin_output_low();
+  const uint32_t elapsed = micros() - edge_us;
+  if (elapsed < LOW_BIT_US) {
+    delay_microseconds_safe(LOW_BIT_US - elapsed);
+  }
+  self->set_pin_input_high();
+#else
+  InterruptLock interrupt_lock;
+  self->set_pin_output_low();
+  delay_microseconds_safe(LOW_BIT_US);
+  self->set_pin_input_high();
+#endif
+}
+
+void HDMI_CEC_RX_ATTR HDMICEC::process_edge_(HDMICEC *self, bool level, uint32_t now) {
+  // on falling edge, store current time as the start of the low pulse
+  if (level == false) {
+    self->rx_last_falling_us_ = now;
 
     if (self->recv_ack_queued_ && !self->monitor_mode_) {
       self->recv_ack_queued_ = false;
-      {
-        InterruptLock interrupt_lock;
-        self->set_pin_output_low();
-        delay_microseconds_safe(LOW_BIT_US);
-        self->set_pin_input_high();
-      }
+      drive_ack_(self, now);
     }
     return;
   }
   // otherwise, it's a rising edge, so it's time to process the pulse length
 
-  auto pulse_duration = (now - self->last_falling_edge_us_);
+  auto pulse_duration = (now - self->rx_last_falling_us_);
 
   if (pulse_duration > START_BIT_MIN_US) {
     // start bit detected. reset everything and start receiving
@@ -651,7 +731,7 @@ void IRAM_ATTR HDMICEC::gpio_intr_(HDMICEC *self) {
   }
 }
 
-void IRAM_ATTR HDMICEC::reset_state_variables_(HDMICEC *self) {
+void HDMI_CEC_RX_ATTR HDMICEC::reset_state_variables_(HDMICEC *self) {
   self->recv_bit_counter_ = 0;
   self->recv_byte_buffer_ = 0x0;
 }

--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -1,6 +1,8 @@
 #include "hdmi_cec.h"
 #include "esphome/core/log.h"
 
+#include <algorithm>
+
 #ifdef USE_CEC_DECODER
 #include "cec_decoder.h"
 #endif
@@ -75,8 +77,104 @@ void HDMICEC::setup() {
   this->pin_->setup();  
   isr_pin_ = pin_->to_isr();
   frames_queue_.reset();
+  tx_results_.reserve(MAX_FRAMES_TO_SEND);
+
+#ifdef USE_ESP32
+  tx_queue_ = xQueueCreate(MAX_FRAMES_TO_SEND, sizeof(TxRecord));
+  if (tx_queue_ == nullptr) {
+    ESP_LOGE(TAG, "could not create the transmit queue");
+    this->mark_failed();
+    return;
+  }
+  BaseType_t created = (tx_core_ < 0)
+      ? xTaskCreate(HDMICEC::tx_task_entry_, "hdmi_cec_tx", TX_TASK_STACK_WORDS, this,
+                    TX_TASK_PRIORITY, &tx_task_)
+      : xTaskCreatePinnedToCore(HDMICEC::tx_task_entry_, "hdmi_cec_tx", TX_TASK_STACK_WORDS, this,
+                                TX_TASK_PRIORITY, &tx_task_, tx_core_);
+  if (created != pdPASS) {
+    ESP_LOGE(TAG, "could not create the transmit task");
+    this->mark_failed();
+    return;
+  }
+#endif
+
   pin_->attach_interrupt(HDMICEC::gpio_intr_, this, gpio::INTERRUPT_ANY_EDGE);
   set_pin_input_high();
+}
+
+#ifdef USE_ESP32
+void HDMICEC::tx_task_entry_(void *param) { static_cast<HDMICEC *>(param)->tx_task_loop_(); }
+
+void HDMICEC::tx_task_loop_() {
+  TxRecord request;
+  while (true) {
+    // The only blocking point. Everything below runs to completion before the next frame is
+    // taken, so the bus has one writer and the retransmission state needs no locking.
+    if (xQueueReceive(tx_queue_, &request, portMAX_DELAY) != pdTRUE || request.length < 1) {
+      continue;
+    }
+    Frame frame;
+    frame.assign(request.bytes, request.bytes + request.length);
+    bool is_broadcast = frame.is_broadcast();
+
+    ESP_LOGD(TAG, "[sending] %s", frame.to_string().c_str());
+    SendResult result = send_with_retries_(frame, is_broadcast);
+    publish_result_(frame, result);
+  }
+}
+#endif
+
+void HDMICEC::publish_result_(const Frame &frame, SendResult result) {
+  TxResultRecord record;
+  record.length = (uint8_t) std::min((size_t) Frame::MAX_LENGTH, frame.size());
+  std::copy(frame.begin(), frame.begin() + record.length, record.bytes);
+  record.result = result;
+
+  LockGuard lock(tx_results_mutex_);
+  if (tx_results_.size() >= (size_t) MAX_FRAMES_TO_SEND) {
+    // The loop task is not draining. Dropping the oldest keeps the newest, which is the one
+    // an automation is most likely still waiting on.
+    tx_results_.erase(tx_results_.begin());
+  }
+  tx_results_.push_back(record);
+}
+
+void HDMICEC::process_send_results_() {
+  std::vector<TxResultRecord> results;
+  {
+    LockGuard lock(tx_results_mutex_);
+    if (tx_results_.empty()) {
+      return;
+    }
+    results.swap(tx_results_);
+  }
+
+  for (const auto &record : results) {
+    if (record.length < 1) {
+      continue;
+    }
+    uint8_t src_addr = ((record.bytes[0] & 0xF0) >> 4);
+    uint8_t dest_addr = (record.bytes[0] & 0x0F);
+    uint8_t opcode = (record.length >= 2) ? record.bytes[1] : 0;
+    std::vector<uint8_t> data(record.bytes + 1, record.bytes + record.length);
+    bool success = (record.result == SendResult::Success);
+
+    if (!success) {
+      ESP_LOGI(TAG, "HDMICEC::send(): frame not sent: %s",
+               ((record.result == SendResult::BusCollision) ? "Bus Collision" : "No Ack received"));
+    }
+
+    for (auto trigger : send_result_triggers_) {
+      bool can_trigger = (
+        (!trigger->source_.has_value()      || (trigger->source_ == src_addr)) &&
+        (!trigger->destination_.has_value() || (trigger->destination_ == dest_addr)) &&
+        (!trigger->opcode_.has_value()      || (trigger->opcode_ == opcode))
+      );
+      if (can_trigger) {
+        trigger->trigger(src_addr, dest_addr, data, success);
+      }
+    }
+  }
 }
 
 void HDMICEC::dump_config() {
@@ -85,9 +183,20 @@ void HDMICEC::dump_config() {
   ESP_LOGCONFIG(TAG, "  address: %x", address_);
   ESP_LOGCONFIG(TAG, "  promiscuous mode: %s", (promiscuous_mode_ ? "yes" : "no"));
   ESP_LOGCONFIG(TAG, "  monitor mode: %s", (monitor_mode_ ? "yes" : "no"));
+#ifdef USE_ESP32
+  if (tx_core_ < 0) {
+    ESP_LOGCONFIG(TAG, "  transmit task core: any");
+  } else {
+    ESP_LOGCONFIG(TAG, "  transmit task core: %d", tx_core_);
+  }
+#endif
 }
 
 void HDMICEC::loop() {
+  // Before the received frames, so an automation that sends from on_message sees the result
+  // of its previous send first.
+  process_send_results_();
+
   while (const Frame *frame = frames_queue_.front()) {
     uint8_t header = frame->front();
     uint8_t src_addr = ((header & 0xF0) >> 4);
@@ -230,19 +339,41 @@ void HDMICEC::try_builtin_handler_(uint8_t source, uint8_t destination, const st
 bool HDMICEC::send(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data_bytes) {
   if (monitor_mode_) return false;
 
-  bool is_broadcast = (destination == 0xF);
-
-  // prepare the bytes to send
   Frame frame(source, destination, data_bytes);
-  ESP_LOGD(TAG, "[sending] %s", frame.to_string().c_str());
+  if (frame.size() > (size_t) Frame::MAX_LENGTH) {
+    ESP_LOGW(TAG, "HDMICEC::send(): frame of %u bytes exceeds the CEC maximum", (unsigned) frame.size());
+    return false;
+  }
 
+#ifdef USE_ESP32
+  TxRecord request;
+  request.length = (uint8_t) frame.size();
+  std::copy(frame.begin(), frame.end(), request.bytes);
+  // Never waits: this runs on the loop task, and a full queue means the bus is already
+  // backed up by a second of traffic. Failing here is better than stalling every automation
+  // behind it.
+  if (xQueueSend(tx_queue_, &request, 0) != pdTRUE) {
+    ESP_LOGW(TAG, "HDMICEC::send(): transmit queue full, dropping %s", frame.to_string(true).c_str());
+    return false;
+  }
+  return true;
+#else
+  // No FreeRTOS here, so the caller pays for the frame as before. The result still travels
+  // through the same buffer, so the trigger fires from loop() on every platform.
+  ESP_LOGD(TAG, "[sending] %s", frame.to_string().c_str());
+  publish_result_(frame, send_with_retries_(frame, frame.is_broadcast()));
+  return true;
+#endif
+}
+
+SendResult HDMICEC::send_with_retries_(const Frame &frame, bool is_broadcast) {
+  SendResult last_result = SendResult::NoAck;
   {
-    LockGuard send_lock(send_mutex_);
     // Bus 'Signal Free' time between transmissions, according to the HDMI-CEC standard, shall be a minimum of:
     //  - 7 bit periods between successive transmissions of same sender
     //  - 5 bit periods between transmissions of different senders
     //  - 3 bit periods for resend of a failed transmission attempt
-    uint8_t free_bit_periods = (last_sent_us_ > last_falling_edge_us_) ? 7 : 5;
+    uint8_t free_bit_periods = (last_sent_us_.load() > last_falling_edge_us_) ? 7 : 5;
 
     // Total timeout: abort if we can't send within 2 seconds (prevents infinite blocking on busy bus)
     static const uint32_t SEND_TIMEOUT_US = 2000000;
@@ -254,11 +385,11 @@ bool HDMICEC::send(uint8_t source, uint8_t destination, const std::vector<uint8_
       const uint32_t attempt_start_us = micros();
       static const uint32_t ATTEMPT_TIMEOUT_US = 200000;
 
-      while ((delay = free_bit_periods * TOTAL_BIT_US + std::max(last_sent_us_, (uint32_t) last_falling_edge_us_) - micros()) > 0) {
+      while ((delay = free_bit_periods * TOTAL_BIT_US + std::max(last_sent_us_.load(), (uint32_t) last_falling_edge_us_) - micros()) > 0) {
         // Check total timeout
         if ((micros() - send_start_us) > SEND_TIMEOUT_US) {
           ESP_LOGW(TAG, "HDMICEC::send(): total timeout reached (2s), aborting");
-          return false;
+          return SendResult::BusCollision;
         }
         // Check per-attempt timeout (bus constantly busy)
         if ((micros() - attempt_start_us) > ATTEMPT_TIMEOUT_US) {
@@ -267,8 +398,15 @@ bool HDMICEC::send(uint8_t source, uint8_t destination, const std::vector<uint8_
         }
         ESP_LOGV(TAG, "HDMICEC::send(): waiting %d usec for bus free period", delay);
         if (delay >= (int32_t) YIELD_INTERVAL_US) {
+#ifdef USE_ESP32
+          // A bus-free period is 12000-16800 us, so the millisecond granularity of a tick
+          // costs nothing here and the core is free for other work meanwhile. Bit timing
+          // below stays on delay_microseconds_safe(); 2400 us is not schedulable.
+          vTaskDelay(pdMS_TO_TICKS(YIELD_INTERVAL_US / 1000));
+#else
           delay_microseconds_safe(YIELD_INTERVAL_US);
           yield();
+#endif
         } else {
           delay_microseconds_safe(delay);
         }
@@ -285,13 +423,13 @@ bool HDMICEC::send(uint8_t source, uint8_t destination, const std::vector<uint8_
 
       ESP_LOGV(TAG, "HDMICEC::send(): bus available, sending frame...");
 
-      auto result = send_frame_(frame, is_broadcast);
-      if (result == SendResult::Success) {
+      last_result = send_frame_(frame, is_broadcast);
+      if (last_result == SendResult::Success) {
         ESP_LOGD(TAG, "frame sent and acknowledged");
-        return true;
+        return last_result;
       }
-      ESP_LOGI(TAG, "HDMICEC::send(): frame not sent: %s",
-               ((result == SendResult::BusCollision) ? "Bus Collision" : "No Ack received"));
+      ESP_LOGV(TAG, "HDMICEC::send(): attempt %d failed: %s", i + 1,
+               ((last_result == SendResult::BusCollision) ? "Bus Collision" : "No Ack received"));
       // attempt retransmission with smaller free time gap
       free_bit_periods = 3;
       yield();
@@ -299,7 +437,7 @@ bool HDMICEC::send(uint8_t source, uint8_t destination, const std::vector<uint8_
   }
 
   ESP_LOGE(TAG, "HDMICEC::send(): send failed after %d attempts", MAX_ATTEMPTS);
-  return false;
+  return last_result;
 }
 
 SendResult HDMICEC::send_frame_(const Frame &frame, bool is_broadcast) {
@@ -344,7 +482,7 @@ SendResult HDMICEC::send_frame_(const Frame &frame, bool is_broadcast) {
     }
   }
   // capture last bus busy time also for bus writes (with interrupts off)
-  last_sent_us_ = micros();
+  last_sent_us_.store(micros());
   pin_->attach_interrupt(HDMICEC::gpio_intr_, this, gpio::INTERRUPT_ANY_EDGE);
   return result;
 }

--- a/components/hdmi_cec/hdmi_cec.cpp
+++ b/components/hdmi_cec/hdmi_cec.cpp
@@ -87,6 +87,11 @@ void HDMICEC::setup() {
   tx_results_.reserve(MAX_FRAMES_TO_SEND);
 
 #ifdef HDMI_CEC_USE_FREERTOS
+  if (tx_core_ >= (int8_t) configNUMBER_OF_CORES) {
+    ESP_LOGW(TAG, "core %d does not exist on this chip, running the tasks unpinned", tx_core_);
+    tx_core_ = -1;
+  }
+
   tx_queue_ = xQueueCreate(MAX_FRAMES_TO_SEND, sizeof(TxRecord));
   if (tx_queue_ == nullptr) {
     ESP_LOGE(TAG, "could not create the transmit queue");

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -7,6 +7,13 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/helpers.h"
+
+#ifdef USE_ESP32
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+#include <freertos/task.h>
+#endif
 
 namespace esphome {
 namespace hdmi_cec {
@@ -35,6 +42,21 @@ enum class SendResult : uint8_t {
   Success = 0,
   BusCollision = 1,
   NoAck = 2,
+};
+
+// A frame waiting to go out, and one that has been out.
+//
+// Both are flat and copyable so they can travel through a FreeRTOS queue by value. A Frame
+// is a std::vector and would have to be passed by pointer, which would put its lifetime in
+// the hands of two tasks; the sixteen bytes a CEC frame can hold are cheaper to copy than
+// that ownership question is to answer.
+struct TxRecord {
+  uint8_t length{0};
+  uint8_t bytes[Frame::MAX_LENGTH]{};
+};
+
+struct TxResultRecord : public TxRecord {
+  SendResult result{SendResult::Success};
 };
 
 /*
@@ -86,6 +108,7 @@ class FrameRingBuffer {
 };
 
 class MessageTrigger;
+class SendResultTrigger;
 
 class HDMICEC : public Component {
 public:
@@ -97,7 +120,15 @@ public:
   void set_monitor_mode(bool monitor_mode) { monitor_mode_ = monitor_mode; }
   void set_osd_name_bytes(const std::vector<uint8_t> &osd_name_bytes) { osd_name_bytes_ = osd_name_bytes; }
   void add_message_trigger(MessageTrigger *trigger) { message_triggers_.push_back(trigger); }
+  void add_send_result_trigger(SendResultTrigger *trigger) { send_result_triggers_.push_back(trigger); }
+  // Core the transmit task runs on, or -1 for no affinity. Sending holds a core for the
+  // duration of the frame, so a build that also does real-time work wants the two apart.
+  void set_tx_core(int8_t tx_core) { tx_core_ = tx_core; }
 
+  // Hands a frame to the transmitter. Returns whether it was accepted, not whether it
+  // reached the bus -- that answer arrives later, through on_send_result. Sending a CEC
+  // frame takes 24 ms per byte plus up to 200 ms of waiting for the bus per attempt, five
+  // attempts deep, and none of that may happen on the loop task.
   bool send(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data_bytes);
 
   // Component overrides
@@ -110,6 +141,11 @@ protected:
   static void gpio_intr_(HDMICEC *self);
   static void reset_state_variables_(HDMICEC *self);
   void try_builtin_handler_(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data);
+  // Bus-free wait, arbitration and retransmission. Blocks for as long as the bus makes it;
+  // only ever called from the transmit task on ESP32, and from send() elsewhere.
+  SendResult send_with_retries_(const Frame &frame, bool is_broadcast);
+  void publish_result_(const Frame &frame, SendResult result);
+  void process_send_results_();
   SendResult send_frame_(const Frame &frame, bool is_broadcast);
   bool send_start_bit_();
   void send_bit_(bool bit_value);
@@ -117,7 +153,25 @@ protected:
   void set_pin_input_high();
   void set_pin_output_low();
 
+#ifdef USE_ESP32
+  static void tx_task_entry_(void *param);
+  void tx_task_loop_();
+
+  TaskHandle_t tx_task_{nullptr};
+  QueueHandle_t tx_queue_{nullptr};
+#endif
+  // Results are collected here by whoever sent the frame and drained by loop(), so the
+  // triggers run on the loop task like every other automation in the component.
+  std::vector<TxResultRecord> tx_results_;
+  Mutex tx_results_mutex_;
+  int8_t tx_core_{-1};
+
   constexpr static int MAX_FRAMES_QUEUED = 4;
+  constexpr static int MAX_FRAMES_TO_SEND = 8;
+  constexpr static int TX_TASK_STACK_WORDS = 3072;
+  // Above the loop task, so a queued frame is not left waiting behind ordinary work, and
+  // well below the timer and Wi-Fi tasks.
+  constexpr static int TX_TASK_PRIORITY = 10;
   InternalGPIOPin *pin_;
   ISRInternalGPIOPin isr_pin_;
   uint8_t address_;
@@ -129,14 +183,16 @@ protected:
 
   bool last_level_ = true;            // cec line level on last isr call
   volatile uint32_t last_falling_edge_us_ = 0; // timepoint in received message (volatile: written by ISR, read by send())
-  uint32_t last_sent_us_ = 0;         // timepoint on end of sent message
+  // Written by the transmit task, read by it and by the bus-free calculation. Atomic
+  // because those are no longer the same task.
+  std::atomic<uint32_t> last_sent_us_{0};  // timepoint on end of sent message
   ReceiverState receiver_state_;
   uint8_t recv_bit_counter_ = 0;
   uint8_t recv_byte_buffer_ = 0;
   Frame *frame_receive_ = nullptr;
   FrameRingBuffer<MAX_FRAMES_QUEUED> frames_queue_;
   bool recv_ack_queued_ = false;
-  Mutex send_mutex_;
+  std::vector<SendResultTrigger*> send_result_triggers_;
 };
 
 class MessageTrigger : public Trigger<uint8_t, uint8_t, std::vector<uint8_t>> {
@@ -154,6 +210,24 @@ protected:
   optional<uint8_t> destination_;
   optional<uint8_t> opcode_;
   optional<std::vector<uint8_t>> data_;
+};
+
+// Fires once per frame the transmitter is done with, successful or not. The filters match
+// the frame that was sent, so an automation can wait for one particular message to be
+// acknowledged before acting on it.
+class SendResultTrigger : public Trigger<uint8_t, uint8_t, std::vector<uint8_t>, bool> {
+  friend class HDMICEC;
+
+public:
+  explicit SendResultTrigger(HDMICEC *parent) { parent->add_send_result_trigger(this); };
+  void set_source(uint8_t source) { source_ = source; };
+  void set_destination(uint8_t destination) { destination_ = destination; };
+  void set_opcode(uint8_t opcode) { opcode_ = opcode; };
+
+protected:
+  optional<uint8_t> source_;
+  optional<uint8_t> destination_;
+  optional<uint8_t> opcode_;
 };
 
 template<typename... Ts> class SendAction : public Action<Ts...> {

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -9,7 +9,13 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/helpers.h"
 
-#ifdef USE_ESP32
+// Platforms that provide a FreeRTOS scheduler run the bit-level work in their own tasks and
+// keep the ISR to a timestamp. Platforms that do not keep the in-line paths below.
+#if defined(USE_ESP32)
+#define HDMI_CEC_USE_FREERTOS
+#endif
+
+#ifdef HDMI_CEC_USE_FREERTOS
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
 #include <freertos/task.h>
@@ -57,6 +63,13 @@ struct TxRecord {
 
 struct TxResultRecord : public TxRecord {
   SendResult result{SendResult::Success};
+};
+
+// One line transition. The ISR records the level and the moment it changed; the decoder
+// runs later, so it has to work from this timestamp and not from the pin.
+struct EdgeEvent {
+  uint32_t us{0};
+  bool level{true};
 };
 
 /*
@@ -140,6 +153,11 @@ public:
 protected:
   static void gpio_intr_(HDMICEC *self);
   static void reset_state_variables_(HDMICEC *self);
+  // Receiver state machine for one line transition. Runs in the receive task where there is
+  // one, and in the ISR where there is not.
+  static void process_edge_(HDMICEC *self, bool level, uint32_t now);
+  // Holds the line low for the remainder of the ack bit that started at edge_us.
+  static void drive_ack_(HDMICEC *self, uint32_t edge_us);
   void try_builtin_handler_(uint8_t source, uint8_t destination, const std::vector<uint8_t> &data);
   // Bus-free wait, arbitration and retransmission. Blocks for as long as the bus makes it;
   // only ever called from the transmit task on ESP32, and from send() elsewhere.
@@ -153,12 +171,23 @@ protected:
   void set_pin_input_high();
   void set_pin_output_low();
 
-#ifdef USE_ESP32
+#ifdef HDMI_CEC_USE_FREERTOS
   static void tx_task_entry_(void *param);
   void tx_task_loop_();
+  static void rx_task_entry_(void *param);
+  void rx_task_loop_();
 
   TaskHandle_t tx_task_{nullptr};
   QueueHandle_t tx_queue_{nullptr};
+  TaskHandle_t rx_task_{nullptr};
+
+  // Single producer (the ISR), single consumer (the receive task), so the two indices need
+  // no lock of their own.
+  constexpr static uint16_t EDGE_QUEUE_SIZE = 128;
+  std::array<EdgeEvent, EDGE_QUEUE_SIZE> edge_queue_{};
+  std::atomic<uint16_t> edge_head_{0};
+  std::atomic<uint16_t> edge_tail_{0};
+  std::atomic<bool> edge_overflow_{false};
 #endif
   // Results are collected here by whoever sent the frame and drained by loop(), so the
   // triggers run on the loop task like every other automation in the component.
@@ -172,6 +201,10 @@ protected:
   // Above the loop task, so a queued frame is not left waiting behind ordinary work, and
   // well below the timer and Wi-Fi tasks.
   constexpr static int TX_TASK_PRIORITY = 10;
+  constexpr static int RX_TASK_STACK_WORDS = 3072;
+  // Above the transmit task: an ack has to go out within the bit that asked for it, and the
+  // transmitter can be busy holding the line for milliseconds at a time.
+  constexpr static int RX_TASK_PRIORITY = 19;
   InternalGPIOPin *pin_;
   ISRInternalGPIOPin isr_pin_;
   uint8_t address_;
@@ -186,6 +219,9 @@ protected:
   // Written by the transmit task, read by it and by the bus-free calculation. Atomic
   // because those are no longer the same task.
   std::atomic<uint32_t> last_sent_us_{0};  // timepoint on end of sent message
+  // The decoder cannot use last_falling_edge_us_: by the time it processes a rising edge the
+  // ISR may already have recorded a later fall.
+  uint32_t rx_last_falling_us_ = 0;
   ReceiverState receiver_state_;
   uint8_t recv_bit_counter_ = 0;
   uint8_t recv_byte_buffer_ = 0;

--- a/components/hdmi_cec/hdmi_cec.h
+++ b/components/hdmi_cec/hdmi_cec.h
@@ -9,12 +9,8 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/helpers.h"
 
-// Platforms that provide a FreeRTOS scheduler run the bit-level work in their own tasks and
-// keep the ISR to a timestamp. Platforms that do not keep the in-line paths below.
-#if defined(USE_ESP32)
-#define HDMI_CEC_USE_FREERTOS
-#endif
-
+// Set by the codegen on platforms that provide the FreeRTOS task API. Those run the
+// bit-level work in tasks; the others keep the in-line paths below.
 #ifdef HDMI_CEC_USE_FREERTOS
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>


### PR DESCRIPTION
Hi !

As title says. Automatic enumeration of platform/capabilities in codegen and respective handling.
Needs further testing, but works fine here now -> simultaneously with other components